### PR TITLE
feat!: ability to unsubscribe connections from audio players

### DIFF
--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -36,6 +36,6 @@ function connectToChannel(channel: VoiceChannel) {
 	const voiceConnection = joinVoiceChannel(channel);
 
 	voiceConnection.once('ready', () => {
-		player.playTo(voiceConnection);
+		player.subscribe(voiceConnection);
 	});
 }

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -36,6 +36,6 @@ function connectToChannel(channel: VoiceChannel) {
 	const voiceConnection = joinVoiceChannel(channel);
 
 	voiceConnection.once('ready', () => {
-		player.subscribe(voiceConnection);
+		voiceConnection.subscribe(player);
 	});
 }

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -366,9 +366,10 @@ export class VoiceConnection extends EventEmitter {
 	 * Subscribes to an audio player, allowing the player to play audio on this voice connection.
 	 *
 	 * @param player The audio player to subscribe to
+	 * @returns The created subscription
 	 */
 	public subscribe(player: AudioPlayer) {
-		if (this.state.status === VoiceConnectionStatus.Destroyed) return false;
+		if (this.state.status === VoiceConnectionStatus.Destroyed) return;
 
 		const unsubscribe = () => {
 			if (this.state.status !== VoiceConnectionStatus.Destroyed && this.state.subscription === subscription) {
@@ -386,7 +387,7 @@ export class VoiceConnection extends EventEmitter {
 			subscription
 		};
 
-		return true;
+		return subscription;
 	}
 }
 

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -380,7 +380,8 @@ export class VoiceConnection extends EventEmitter {
 			}
 		};
 
-		const subscription = player.subscribe(this, unsubscribe);
+		// eslint-disable-next-line @typescript-eslint/dot-notation
+		const subscription = player['subscribe'](this, unsubscribe);
 
 		this.state = {
 			...this.state,

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -369,16 +369,8 @@ export class VoiceConnection extends EventEmitter {
 	 */
 	public subscribe(player: AudioPlayer) {
 		if (this.state.status === VoiceConnectionStatus.Destroyed) return false;
-		const subscription = player.subscribe(this);
 
-		/*
-			The audio player returns a subscription with an unsubscribe function that will only remove the subscription
-			from the player's internal tracker. Below, the function is patched to additionally remove the subscription
-			from this voice connection to ensure consistency.
-		*/
-		const unsubscribe = subscription.unsubscribe;
-		subscription.unsubscribe = () => {
-			unsubscribe();
+		const unsubscribe = () => {
 			if (this.state.status !== VoiceConnectionStatus.Destroyed && this.state.subscription === subscription) {
 				this.state = {
 					...this.state,
@@ -387,10 +379,13 @@ export class VoiceConnection extends EventEmitter {
 			}
 		};
 
+		const subscription = player.subscribe(this, unsubscribe);
+
 		this.state = {
 			...this.state,
 			subscription
 		};
+
 		return true;
 	}
 }

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -354,7 +354,7 @@ export class VoiceConnection extends EventEmitter {
  * Creates a new voice connection
  * @param joinConfig The data required to establish the voice connection
  */
-export function createVoiceConnection(joinConfig: JoinConfig, options?: JoinVoiceChannelOptions) {
+export function createVoiceConnection(joinConfig: JoinConfig, options: JoinVoiceChannelOptions) {
 	const existing = getVoiceConnection(joinConfig.guild.id);
 	if (existing) return existing;
 

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -333,8 +333,8 @@ export class AudioPlayer extends EventEmitter {
 
 		// List of connections that can receive the packet
 		const playable = this.subscribers
-			.map(({ connection }) => connection)
-			.filter(connection => connection.state.status === VoiceConnectionStatus.Ready);
+			.filter(({ connection }) => connection.state.status === VoiceConnectionStatus.Ready)
+			.map(({ connection }) => connection);
 
 		// Dispatch any audio packets that were prepared in the previous cycle
 		playable.forEach(connection => connection.dispatchAudio());

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -129,6 +129,17 @@ export class AudioPlayer extends EventEmitter {
 	}
 
 	/**
+	 * Removes a VoiceConnection from this player's connection list. This unsubscribes the VoiceConnection to all
+	 * resources that this player will stream.
+	 *
+	 * If the connection is not in the play list, this method does nothing.
+	 */
+	public unsubscribe(connection: VoiceConnection) {
+		const index = this.connections.indexOf(connection);
+		if (index !== -1) this.connections.splice(index, 1);
+	}
+
+	/**
 	 * The state that the player is in.
 	 */
 	public get state() {

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -107,9 +107,7 @@ export class AudioPlayer extends EventEmitter {
 	 */
 	public constructor(options: CreateAudioPlayerOptions) {
 		super();
-		this._state = {
-			status: AudioPlayerStatus.Idle
-		};
+		this._state = { status: AudioPlayerStatus.Idle };
 		this.behaviours = options.behaviours;
 		this.debug = options.debug ? this.emit.bind(this, 'debug') : null;
 	}

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -139,12 +139,15 @@ export class AudioPlayer extends EventEmitter {
 	 * @param connection The connection to subscribe
 	 * @returns The new subscription if the voice connection is not yet subscribed, otherwise the existing subscription.
 	 */
-	public subscribe(connection: VoiceConnection) {
+	public subscribe(connection: VoiceConnection, unsubscribeCallback: () => void) {
 		const existingSubscription = this.subscribers.find(subscription => subscription.connection === connection);
 		if (!existingSubscription) {
 			const subscription: PlayerSubscription = {
 				connection,
-				unsubscribe: () => this.unsubscribe(subscription)
+				unsubscribe: () => {
+					unsubscribeCallback();
+					this.unsubscribe(subscription);
+				}
 			};
 			this.subscribers.push(subscription);
 			return subscription;

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -88,7 +88,7 @@ export class AudioPlayer extends EventEmitter {
 	 * A list of VoiceConnections that are registered to this AudioPlayer. The player will attempt to play audio
 	 * to the streams in this list.
 	 */
-	private readonly subscribers: PlayerSubscription[];
+	private readonly subscribers: PlayerSubscription[] = [];
 
 	/**
 	 * The behaviour that the player should follow when it enters certain situations.
@@ -107,7 +107,6 @@ export class AudioPlayer extends EventEmitter {
 	 */
 	public constructor(options: CreateAudioPlayerOptions) {
 		super();
-		this.subscribers = [];
 		this._state = {
 			status: AudioPlayerStatus.Idle
 		};

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -122,7 +122,7 @@ export class AudioPlayer extends EventEmitter {
 	 *
 	 * @param connection The connection to play to
 	 */
-	public playTo(connection: VoiceConnection) {
+	public subscribe(connection: VoiceConnection) {
 		if (!this.connections.includes(connection)) {
 			this.connections.push(connection);
 		}

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -171,7 +171,7 @@ export class AudioPlayer extends EventEmitter {
 	 *
 	 * @private
 	 * @param subscription The subscription to remove
-	 * @returns true if the subscription exists on the player and was removed, false otherwise.
+	 * @returns Whether or not the subscription existed on the player and was removed.
 	 */
 	public unsubscribe(subscription: PlayerSubscription) {
 		const index = this.subscribers.indexOf(subscription);

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -118,10 +118,14 @@ export class AudioPlayer extends EventEmitter {
 	 * Adds a VoiceConnection to this player's connection list. This subscribes the VoiceConnection to all resources
 	 * that this player will stream.
 	 *
+	 * If the connection is already in the play list, this method does nothing.
+	 *
 	 * @param connection The connection to play to
 	 */
 	public playTo(connection: VoiceConnection) {
-		this.connections.push(connection);
+		if (!this.connections.includes(connection)) {
+			this.connections.push(connection);
+		}
 	}
 
 	/**

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -150,6 +150,15 @@ export class AudioPlayer extends EventEmitter {
 				}
 			};
 			this.subscribers.push(subscription);
+
+			/**
+			 * Emitted when a new subscriber is added to the audio player.
+			 *
+			 * @event AudioPlayer#subscribe
+			 * @type {PlayerSubscription}
+			 */
+			this.emit('subscribe', subscription);
+
 			return subscription;
 		}
 		return existingSubscription;
@@ -170,6 +179,14 @@ export class AudioPlayer extends EventEmitter {
 		if (exists) {
 			this.subscribers.splice(index, 1);
 			subscription.connection.setSpeaking(false);
+
+			/**
+			 * Emitted when a subscription is removed from the audio player.
+			 *
+			 * @event AudioPlayer#unsubscribe
+			 * @type {PlayerSubscription}
+			 */
+			this.emit('unsubscribe', subscription);
 		}
 		return exists;
 	}

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -136,7 +136,7 @@ export class AudioPlayer extends EventEmitter {
 			 * @event AudioPlayer#subscribe
 			 * @type {PlayerSubscription}
 			 */
-			this.emit('subscribe', subscription);
+			setImmediate(() => this.emit('subscribe', subscription));
 
 			return subscription;
 		}

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -139,7 +139,7 @@ export class AudioPlayer extends EventEmitter {
 	 * @param connection The connection to subscribe
 	 * @returns The new subscription if the voice connection is not yet subscribed, otherwise the existing subscription.
 	 */
-	public subscribe(connection: VoiceConnection, unsubscribeCallback: () => void) {
+	private subscribe(connection: VoiceConnection, unsubscribeCallback: () => void) {
 		const existingSubscription = this.subscribers.find(subscription => subscription.connection === connection);
 		if (!existingSubscription) {
 			const subscription: PlayerSubscription = {
@@ -173,7 +173,7 @@ export class AudioPlayer extends EventEmitter {
 	 * @param subscription The subscription to remove
 	 * @returns Whether or not the subscription existed on the player and was removed.
 	 */
-	public unsubscribe(subscription: PlayerSubscription) {
+	private unsubscribe(subscription: PlayerSubscription) {
 		const index = this.subscribers.indexOf(subscription);
 		const exists = index !== -1;
 		if (exists) {

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -133,6 +133,9 @@ export class AudioPlayer extends EventEmitter {
 	 * Subscribes a VoiceConnection to the audio player's play list. If the VoiceConnection is already subscribed,
 	 * then the existing subscription is used.
 	 *
+	 * This method should not be directly called. Instead, use VoiceConnection#subscribe.
+	 *
+	 * @private
 	 * @param connection The connection to subscribe
 	 * @returns The new subscription if the voice connection is not yet subscribed, otherwise the existing subscription.
 	 */
@@ -152,6 +155,9 @@ export class AudioPlayer extends EventEmitter {
 	/**
 	 * Unsubscribes a subscription - i.e. removes a voice connection from the play list of the audio player.
 	 *
+	 * This method should not be directly called. Instead, use PlayerSubscription#unsubscribe.
+	 *
+	 * @private
 	 * @param subscription The subscription to remove
 	 * @returns true if the subscription exists on the player and was removed, false otherwise.
 	 */

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -306,10 +306,12 @@ export class AudioPlayer extends EventEmitter {
 		state.nextTime += FRAME_LENGTH;
 
 		// List of connections that can receive the packet
-		const playable = this.subscribers.filter(({ connection }) => connection.state.status === VoiceConnectionStatus.Ready);
+		const playable = this.subscribers
+			.map(({ connection }) => connection)
+			.filter(connection => connection.state.status === VoiceConnectionStatus.Ready);
 
 		// Dispatch any audio packets that were prepared in the previous cycle
-		playable.forEach(({ connection }) => connection.dispatchAudio());
+		playable.forEach(connection => connection.dispatchAudio());
 
 		/* If the player was previously in the AutoPaused state, check to see whether there are newly available
 		   connections, allowing us to transition out of the AutoPaused state back into the Playing state */
@@ -386,8 +388,8 @@ export class AudioPlayer extends EventEmitter {
 	 * @param packet The Opus packet to be prepared by each receiver
 	 * @param receivers The connections that should play this packet
 	 */
-	private _preparePacket(packet: Buffer, receivers = this.subscribers) {
-		receivers.forEach(({ connection }) => connection.prepareAudioPacket(packet));
+	private _preparePacket(packet: Buffer, receivers: VoiceConnection[]) {
+		receivers.forEach(connection => connection.prepareAudioPacket(packet));
 	}
 }
 

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -87,7 +87,7 @@ export class AudioPlayer extends EventEmitter {
 	 * A list of VoiceConnections that are registered to this AudioPlayer. The player will attempt to play audio
 	 * to the streams in this list.
 	 */
-	private readonly connections: VoiceConnection[];
+	private readonly subscribers: VoiceConnection[];
 
 	/**
 	 * The behaviour that the player should follow when it enters certain situations.
@@ -106,7 +106,7 @@ export class AudioPlayer extends EventEmitter {
 	 */
 	public constructor(options: CreateAudioPlayerOptions) {
 		super();
-		this.connections = [];
+		this.subscribers = [];
 		this._state = {
 			status: AudioPlayerStatus.Idle
 		};
@@ -123,8 +123,8 @@ export class AudioPlayer extends EventEmitter {
 	 * @param connection The connection to play to
 	 */
 	public subscribe(connection: VoiceConnection) {
-		if (!this.connections.includes(connection)) {
-			this.connections.push(connection);
+		if (!this.subscribers.includes(connection)) {
+			this.subscribers.push(connection);
 		}
 	}
 
@@ -135,8 +135,8 @@ export class AudioPlayer extends EventEmitter {
 	 * If the connection is not in the play list, this method does nothing.
 	 */
 	public unsubscribe(connection: VoiceConnection) {
-		const index = this.connections.indexOf(connection);
-		if (index !== -1) this.connections.splice(index, 1);
+		const index = this.subscribers.indexOf(connection);
+		if (index !== -1) this.subscribers.splice(index, 1);
 	}
 
 	/**
@@ -280,7 +280,7 @@ export class AudioPlayer extends EventEmitter {
 		state.nextTime += FRAME_LENGTH;
 
 		// List of connections that can receive the packet
-		const playable = this.connections.filter(connection => connection.state.status === VoiceConnectionStatus.Ready);
+		const playable = this.subscribers.filter(connection => connection.state.status === VoiceConnectionStatus.Ready);
 
 		// Dispatch any audio packets that were prepared in the previous cycle
 		playable.forEach(connection => connection.dispatchAudio());
@@ -350,7 +350,7 @@ export class AudioPlayer extends EventEmitter {
 	 * they are no longer speaking. Called once playback of a resource ends.
 	 */
 	private _signalStopSpeaking() {
-		return this.connections.forEach(connection => connection.setSpeaking(false));
+		return this.subscribers.forEach(connection => connection.setSpeaking(false));
 	}
 
 	/**
@@ -360,7 +360,7 @@ export class AudioPlayer extends EventEmitter {
 	 * @param packet The Opus packet to be prepared by each receiver
 	 * @param receivers The connections that should play this packet
 	 */
-	private _preparePacket(packet: Buffer, receivers = this.connections) {
+	private _preparePacket(packet: Buffer, receivers = this.subscribers) {
 		receivers.forEach(connection => connection.prepareAudioPacket(packet));
 	}
 }

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -73,7 +73,7 @@ type AudioPlayerState = {
 /**
  * Represents a subscription of a voice connection to an audio player.
  */
-interface PlayerSubscription {
+export interface PlayerSubscription {
 	/**
 	 * The connection part of the subscription. While subscribed, audio can be played to it.
 	 */
@@ -137,7 +137,7 @@ export class AudioPlayer extends EventEmitter {
 	 * @returns The new subscription if the voice connection is not yet subscribed, otherwise the existing subscription.
 	 */
 	public subscribe(connection: VoiceConnection) {
-		const existingSubscription = this.subscribers.some(subscription => subscription.connection === connection);
+		const existingSubscription = this.subscribers.find(subscription => subscription.connection === connection);
 		if (!existingSubscription) {
 			const subscription: PlayerSubscription = {
 				connection,
@@ -157,8 +157,11 @@ export class AudioPlayer extends EventEmitter {
 	 */
 	public unsubscribe(subscription: PlayerSubscription) {
 		const index = this.subscribers.indexOf(subscription);
-		const exists = index === -1;
-		if (exists) this.subscribers.splice(index, 1);
+		const exists = index !== -1;
+		if (exists) {
+			this.subscribers.splice(index, 1);
+			subscription.connection.setSpeaking(false);
+		}
 		return exists;
 	}
 

--- a/src/audio/PlayerSubscription.ts
+++ b/src/audio/PlayerSubscription.ts
@@ -27,7 +27,7 @@ export class PlayerSubscription {
 	 * audio player cannot stream audio to it until a new subscription is made.
 	 */
 	public unsubscribe() {
-		this.player['unsubscribe'](this);
 		this.connection['onSubscriptionRemoved'](this);
+		this.player['unsubscribe'](this);
 	}
 }

--- a/src/audio/PlayerSubscription.ts
+++ b/src/audio/PlayerSubscription.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/dot-notation */
+import { VoiceConnection } from '../VoiceConnection';
+import { AudioPlayer } from './AudioPlayer';
+
+/**
+ * Represents a subscription of a voice connection to an audio player, allowing
+ * the audio player to play audio on the voice connection.
+ */
+export class PlayerSubscription {
+	/**
+	 * The voice connection of this subscription
+	 */
+	public readonly connection: VoiceConnection;
+
+	/**
+	 * The audio player of this subscription
+	 */
+	public readonly player: AudioPlayer;
+
+	public constructor(connection: VoiceConnection, player: AudioPlayer) {
+		this.connection = connection;
+		this.player = player;
+	}
+
+	/**
+	 * Unsubscribes the connection from the audio player, meaning that the
+	 * audio player cannot stream audio to it until a new subscription is made.
+	 */
+	public unsubscribe() {
+		this.player['unsubscribe'](this);
+		this.connection['onSubscriptionRemoved'](this);
+	}
+}


### PR DESCRIPTION
Resolves #4 

- [x] Adds an `unsubscribe` method
  - Done via the PlayerSubscription interface
- [x] When destroyed, VoiceConnections are removed from subscriber list
  - Done implicitly in the state transition to Destroyed
- [x] VoiceConnections ensure that they are only tracked by one audio player
  - Done implictly in the state transition
- [x] Adds events for subscribing/unsubscribing to AudioPlayer
  - Adds `subscribe` and `unsubscribe` events to audio player