### PR TITLE
fix(VoiceConnection): correctly compare subscriptions in state transition

### DIFF
--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -123,7 +123,7 @@ export class VoiceConnection extends EventEmitter {
 		const newNetworking: Networking|undefined = Reflect.get(newState, 'networking');
 
 		const oldSubscription: PlayerSubscription|undefined = Reflect.get(oldState, 'subscription');
-		const newSubscription: PlayerSubscription|undefined = Reflect.get(oldState, 'subscription');
+		const newSubscription: PlayerSubscription|undefined = Reflect.get(newState, 'subscription');
 
 		if (oldNetworking && oldNetworking !== newNetworking) {
 			oldNetworking.off('debug', this.onNetworkingDebug);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Line 126 was a duplicate of line 125 when line 126 should have had `oldState` replaced with `newState`


**Status and versioning classification:**
Are we versioning already?
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
