### PR TITLE
fix(VoiceConnection): unsubscribing + moving channels

### DIFF
--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -419,7 +419,14 @@ export class VoiceConnection extends EventEmitter {
  */
 export function createVoiceConnection(joinConfig: JoinConfig, options: JoinVoiceChannelOptions) {
 	const existing = getVoiceConnection(joinConfig.guild.id);
-	if (existing) return existing;
+	if (existing) {
+		existing.state = {
+			...existing.state,
+			status: VoiceConnectionStatus.Signalling,
+		};
+		signalJoinVoiceChannel(joinConfig);
+		return existing;
+	}
 
 	const voiceConnection = new VoiceConnection(joinConfig, options);
 	trackVoiceConnection(joinConfig.guild.id, voiceConnection);

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -145,15 +145,15 @@ export class VoiceConnection extends EventEmitter {
 			oldNetworking.destroy();
 		}
 
-		if (oldSubscription && oldSubscription !== newSubscription) {
-			oldSubscription.unsubscribe();
-		}
-
 		if (newState.status === VoiceConnectionStatus.Ready) {
 			this.reconnectAttempts = 0;
 		}
 
 		this._state = newState;
+
+		if (oldSubscription && oldSubscription !== newSubscription) {
+			oldSubscription.unsubscribe();
+		}
 
 		this.emit('stateChange', oldState, newState);
 		if (oldState.status !== newState.status) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Fixes a bug where attempting to unsubscribe a PlayerSubscription would enter a stack overflow error. The `unsubscribe()` method would call `VoiceConnection#onSubscriptionRemoved()`. This would attempt to call `unsubscribe()` to remove the subscription, however this would again call `onSubscriptionRemoved()`. This would repeat until the overflow error occurs. Fixing this required updating the state before calling `.unsubscribe()` on the subscription, to prevent further calls being made.
- Fixes a bug where you couldn't update the voice state (channel, self mute, self deafen) on an existing voice connection without destroying it first. Now, existing voice connections revert to the Signalling state and a voice state update is sent.


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
