### PR TITLE
chore(GitHub): remove typings line from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,6 @@
 <!--
 Please move lines that apply to you out of the comment:
 - Code changes have been tested against the Discord API, or there are no code changes
-- I know how to update typings and have done so, or typings don't need updating
 - This PR changes the library's interface (methods or parameters added)
 - This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
 - This PR **only** includes non-code changes, like changes to documentation, README, etc.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The typings line is an oversight we missed during the review of the PR templates, this project does not have typings (instead, it generates them), so it's never applicable.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
