### PR TITLE
refactor(TransformerGraph): extra constraint satisfaction

### DIFF
--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -53,6 +53,11 @@ export interface AudioResource {
 	volume?: VolumeTransformer;
 }
 
+/**
+ * Ensures that a path contains at least one volume transforming component
+ *
+ * @param path The path to validate constraints on
+ */
 const VOLUME_CONSTRAINT = (path: Edge[]) => path.some((edge) => edge.type === TransformerType.InlineVolume);
 
 /**
@@ -85,13 +90,13 @@ export function createAudioResource(input: string | Readable, options: CreateAud
 			pipeline: [],
 		};
 	}
-	const streams = [...transformerPipeline.map((pipe) => pipe.transformer(input))];
+	const streams = transformerPipeline.map((pipe) => pipe.transformer(input));
 	if (typeof input !== 'string') streams.unshift(input);
 
 	// the callback is called once the stream ends
 	const playStream = pipeline(streams, noop);
-	// @types/node seems to be incorrect here - the output can still implement Readable
 
+	// attempt to find the volume transformer in the pipeline (if one exists)
 	const volume = streams.find((stream) => stream instanceof VolumeTransformer) as VolumeTransformer | undefined;
 
 	return {

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -1,4 +1,4 @@
-import { findTransformerPipeline, StreamType, TransformerPathComponent } from './TransformerGraph';
+import { findTransformerPipeline, StreamType, TransformerPathComponent, TransformerType } from './TransformerGraph';
 import { pipeline, Readable } from 'stream';
 import { noop } from '../util/util';
 import { VolumeTransformer, opus } from 'prism-media';
@@ -116,6 +116,7 @@ function insertInlineVolumeTransformer(transformerPipeline: TransformerPathCompo
 		to: StreamType.Raw,
 		cost: 0.5,
 		transformer: () => volumeTransformer,
+		type: TransformerType.InlineVolume,
 	};
 
 	// The best insertion would be immediately after a Raw phase in the pipeline
@@ -133,6 +134,7 @@ function insertInlineVolumeTransformer(transformerPipeline: TransformerPathCompo
 		from: StreamType.Opus,
 		to: StreamType.Raw,
 		transformer: () => new opus.Decoder({ rate: 48000, channels: 2, frameSize: 960 }),
+		type: TransformerType.OpusDecoder,
 	});
 
 	transformerPipeline.push(transformer);
@@ -142,6 +144,7 @@ function insertInlineVolumeTransformer(transformerPipeline: TransformerPathCompo
 		from: StreamType.Raw,
 		to: StreamType.Opus,
 		transformer: () => new opus.Encoder({ rate: 48000, channels: 2, frameSize: 960 }),
+		type: TransformerType.OpusEncoder,
 	});
 	return volumeTransformer;
 }

--- a/src/audio/TransformerGraph.ts
+++ b/src/audio/TransformerGraph.ts
@@ -38,21 +38,13 @@ export enum TransformerType {
 	OpusDecoder = 'opus decoder',
 	OggOpusDemuxer = 'ogg opus demuxer',
 	WebmOpusDemuxer = 'webm opus demuxer',
-}
-
-/**
- * Represents a transformer within the transformer pipeline.
- */
-interface TransformerComponent {
-	transformer: (input: string | Readable) => Readable;
-	cost: number;
-	type: TransformerType;
+	InlineVolume = 'inline volume',
 }
 
 /**
  * Represents a section of the transformer pipeline.
  */
-export interface TransformerPathComponent extends TransformerComponent {
+export interface TransformerPathComponent {
 	/**
 	 * The StreamType that comes into this transformer (its input)
 	 */
@@ -77,12 +69,17 @@ export interface TransformerPathComponent extends TransformerComponent {
 	 * transformer components will have higher costs.
 	 */
 	cost: number;
+
+	/**
+	 * The type of this transformer component
+	 */
+	type: TransformerType;
 }
 
 type Node = StreamType;
 type Edge = [Node, Node];
 
-const GRAPH: Map<Edge, TransformerComponent> = new Map();
+const GRAPH: Map<Edge, Omit<TransformerPathComponent, 'from' | 'to'>> = new Map();
 
 GRAPH.set([StreamType.Raw, StreamType.Opus], {
 	transformer: () => new prism.opus.Encoder({ rate: 48000, channels: 2, frameSize: 960 }),

--- a/src/audio/TransformerGraph.ts
+++ b/src/audio/TransformerGraph.ts
@@ -80,7 +80,7 @@ export class Node {
 }
 
 // Create a node for each stream type
-const NODES: Map<StreamType, Node> = new Map();
+const NODES = new Map<StreamType, Node>();
 for (const streamType of Object.values(StreamType)) {
 	NODES.set(streamType, new Node(streamType));
 }

--- a/src/audio/TransformerGraph.ts
+++ b/src/audio/TransformerGraph.ts
@@ -117,6 +117,13 @@ getNode(StreamType.Arbitrary).addEdge({
 		}),
 });
 
+getNode(StreamType.Raw).addEdge({
+	type: TransformerType.InlineVolume,
+	to: getNode(StreamType.Raw),
+	cost: 0.25,
+	transformer: () => new prism.VolumeTransformer({ type: 's16le', volume: 1 }),
+});
+
 /**
  * Returns all the outbound edges from a given node
  * @param node The source node
@@ -193,4 +200,4 @@ export function findTransformerPipeline(start: Node, goal = getNode(StreamType.O
 	return transformerPath;
 }
 
-// console.log(findTransformerPipeline(getNode(StreamType.OggOpus)));
+console.log(findTransformerPipeline(getNode(StreamType.Arbitrary)));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR refactors the transformer graph to a format that is more suitable for constraint satisfaction. One use case has already been implemented, which is volume transforming. Now you can specify that the outputted pipeline should include a volume transformer, and the graph functions will find the lowest cost pipeline that will achieve this.

This will make it possible to address #21. Without this change, it would have been possible for a stream that requires inline volume to have been transcoded to .ogg by FFmpeg (had the change been implemented). However, the extra cost of demuxing, decoding, transforming, then encoding the stream would have outweighed the cost of just transforming the stream to PCM. This PR prevents this issue from arising.


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes