### PR TITLE
feat(TransformerGraph): add FFmpeg opus optimization

### DIFF
--- a/src/audio/TransformerGraph.ts
+++ b/src/audio/TransformerGraph.ts
@@ -163,7 +163,7 @@ getNode(StreamType.Raw).addEdge({
 function canEnableFFmpegOptimisations(): boolean {
 	try {
 		return prism.FFmpeg.getInfo().output.includes('--enable-libopus');
-	} catch (err) {}
+	} catch {}
 	return false;
 }
 

--- a/src/audio/TransformerGraph.ts
+++ b/src/audio/TransformerGraph.ts
@@ -160,14 +160,14 @@ getNode(StreamType.Raw).addEdge({
 });
 
 // Try to enable FFmpeg Ogg optimisations
-function canEnableFFmpegOptimisations(): boolean {
+function canEnableFFmpegOptimizations(): boolean {
 	try {
 		return prism.FFmpeg.getInfo().output.includes('--enable-libopus');
 	} catch {}
 	return false;
 }
 
-if (canEnableFFmpegOptimisations()) {
+if (canEnableFFmpegOptimizations()) {
 	const FFMPEG_OGG_EDGE: Omit<Edge, 'from'> = {
 		type: TransformerType.FFmpegOgg,
 		to: getNode(StreamType.OggOpus),

--- a/src/audio/TransformerGraph.ts
+++ b/src/audio/TransformerGraph.ts
@@ -162,8 +162,7 @@ getNode(StreamType.Raw).addEdge({
 // Try to enable FFmpeg Ogg optimisations
 function canEnableFFmpegOptimisations(): boolean {
 	try {
-		const info = prism.FFmpeg.getInfo();
-		return info.output.includes('--enable-libopus');
+		return prism.FFmpeg.getInfo().output.includes('--enable-libopus');
 	} catch (err) {}
 	return false;
 }

--- a/src/audio/TransformerGraph.ts
+++ b/src/audio/TransformerGraph.ts
@@ -251,7 +251,6 @@ function constructPipeline(step: Step) {
 		edges.push(current.edge);
 		current = current.next;
 	}
-	console.log(edges);
 	return edges;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #21.

If the user's FFmpeg installation was compiled with `--enable-libopus`, then we are able to enable an optimisation for certain use cases. This optimisation will use FFmpeg to give an OggOpus output rather than a raw audio output that needs to be encoded to Opus. This allows for:

- No requirement of an Opus library
- Around 10% faster to process the entire audio stream

This requires less work to be done by the library, which is a nice bonus for performance too!

**This optimisation is only taken for arbitrary streams with inline volume disabled**. If you would like to use inline volume, you'll still need an Opus library.



**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes