### PR TITLE
refactor(AudioResource): implement locking

### DIFF
--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -263,7 +263,10 @@ export class AudioPlayer extends EventEmitter {
 			throw new Error(`Cannot play a resource (${resource.name ?? 'unnamed'}) that has already ended.`);
 		}
 
-		if (resource.audioPlayer && resource.audioPlayer !== this) {
+		if (resource.audioPlayer) {
+			if (resource.audioPlayer === this) {
+				return;
+			}
 			throw new Error(`Resource (${resource.name ?? 'unnamed'}) is already being played by another audio player.`);
 		}
 		resource.audioPlayer = this;

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -2,6 +2,7 @@ import { Edge, findPipeline, StreamType, TransformerType } from './TransformerGr
 import { pipeline, Readable } from 'stream';
 import { noop } from '../util/util';
 import { VolumeTransformer } from 'prism-media';
+import { AudioPlayer } from './AudioPlayer';
 
 /**
  * Options that are set when creating a new audio resource.
@@ -51,6 +52,11 @@ export class AudioResource {
 	 * prism-media VolumeTransformer. You can use this to alter the volume of the stream.
 	 */
 	public readonly volume?: VolumeTransformer;
+
+	/**
+	 * The audio player that the resource is subscribed to, if any.
+	 */
+	public audioPlayer?: AudioPlayer;
 
 	public constructor(pipeline: Edge[], playStream: Readable, name?: string, volume?: VolumeTransformer) {
 		this.pipeline = pipeline;

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -2,7 +2,7 @@ import { Edge, findPipeline, StreamType, TransformerType } from './TransformerGr
 import { pipeline, Readable } from 'stream';
 import { noop } from '../util/util';
 import { VolumeTransformer } from 'prism-media';
-import { AudioPlayer } from './AudioPlayer';
+import type { AudioPlayer } from './AudioPlayer';
 
 /**
  * Options that are set when creating a new audio resource.

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -28,29 +28,36 @@ interface CreateAudioResourceOptions {
 /**
  * Represents an audio resource that can be played by an audio player.
  */
-export interface AudioResource {
+export class AudioResource {
 	/**
 	 * An object-mode Readable stream that emits Opus packets. This is what is played by audio players.
 	 */
-	playStream: Readable;
+	public readonly playStream: Readable;
 
 	/**
 	 * The pipeline used to convert the input stream into a playable format. For example, this may
 	 * contain an FFmpeg component for arbitrary inputs, and it may contain a VolumeTransformer component
 	 * for resources with inline volume transformation enabled.
 	 */
-	pipeline: Edge[];
+	public readonly pipeline: Edge[];
 
 	/**
 	 * An optional name that can be used to identify the resource.
 	 */
-	name?: string;
+	public name?: string;
 
 	/**
 	 * If the resource was created with inline volume transformation enabled, then this will be a
 	 * prism-media VolumeTransformer. You can use this to alter the volume of the stream.
 	 */
-	volume?: VolumeTransformer;
+	public readonly volume?: VolumeTransformer;
+
+	public constructor(pipeline: Edge[], playStream: Readable, name?: string, volume?: VolumeTransformer) {
+		this.pipeline = pipeline;
+		this.playStream = playStream;
+		this.name = name;
+		this.volume = volume;
+	}
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #48 

This PR implements locking for audio resources to prevent audio resources from being played on more than one player simultaneously.

Attempting to play an audio resource that is locked by another player will result in an error being thrown in the `AudioPlayer#play(resource)` method. This method is also idempotent - attempting to play the same resource on the same player repeatedly will result in nothing happening.


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
