### PR TITLE
refactor: use global timer for audio players

### DIFF
--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -143,7 +143,6 @@ export function addAudioPlayer(player: AudioPlayer) {
 export function deleteAudioPlayer(player: AudioPlayer) {
 	const index = audioPlayers.indexOf(player);
 	if (index === -1) return;
-	
 	audioPlayers.splice(index, 1);
 	if (audioPlayers.length === 0 && typeof audioCycleInterval !== 'undefined') {
 		nextTime = -1;

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -99,8 +99,10 @@ function audioCycleStep() {
 function prepareNextAudioFrame(players: AudioPlayer[]) {
 	const nextPlayer = players.shift();
 
-	if (!nextPlayer && nextTime !== -1) {
-		audioCycleInterval = setTimeout(() => audioCycleStep(), nextTime - Date.now());
+	if (!nextPlayer) {
+		if (nextTime !== -1) {
+			audioCycleInterval = setTimeout(() => audioCycleStep(), nextTime - Date.now());
+		}
 		return;
 	}
 

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -120,7 +120,7 @@ function prepareNextAudioFrame(players: AudioPlayer[]) {
  * @returns true if it is being tracked, false otherwise
  */
 export function hasAudioPlayer(target: AudioPlayer) {
-	return audioPlayers.some((player) => player === target);
+	return audioPlayers.includes(target);
 }
 
 /**
@@ -141,12 +141,10 @@ export function addAudioPlayer(player: AudioPlayer) {
  * Removes an audio player from the data store tracking list, if it is present there.
  */
 export function deleteAudioPlayer(player: AudioPlayer) {
-	for (let i = 0; i < audioPlayers.length; i++) {
-		if (audioPlayers[i] === player) {
-			audioPlayers.splice(i, 1);
-			break;
-		}
-	}
+	const index = audioPlayers.indexOf(player);
+	if (index === -1) return;
+	
+	audioPlayers.splice(index, 1);
 	if (audioPlayers.length === 0 && typeof audioCycleInterval !== 'undefined') {
 		nextTime = -1;
 		clearTimeout(audioCycleInterval);

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -66,12 +66,16 @@ export function trackVoiceConnection(guildId: string, voiceConnection: VoiceConn
 }
 
 // Audio Players
+
+// Each audio packet is 20ms long
+const FRAME_LENGTH = 20;
+
 let audioCycleInterval: NodeJS.Timeout | undefined;
 let nextTime = -1;
 const audioPlayers: AudioPlayer[] = [];
 
 function audioCycleStep() {
-	nextTime += 20;
+	nextTime += FRAME_LENGTH;
 	const available = audioPlayers.filter(
 		(player) => player.state.status !== AudioPlayerStatus.Idle && player.state.status !== AudioPlayerStatus.Buffering,
 	);

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -4,7 +4,7 @@ import {
 	GatewayVoiceStateUpdateDispatchData,
 } from 'discord-api-types/v8/gateway';
 import { Client, Constants, Guild } from 'discord.js';
-import { AudioPlayer, AudioPlayerStatus } from './audio';
+import { AudioPlayer } from './audio';
 import { VoiceConnection } from './VoiceConnection';
 
 // Clients
@@ -76,12 +76,12 @@ const audioPlayers: AudioPlayer[] = [];
 
 function audioCycleStep() {
 	nextTime += FRAME_LENGTH;
-	const available = audioPlayers.filter(
-		(player) => player.state.status !== AudioPlayerStatus.Idle && player.state.status !== AudioPlayerStatus.Buffering,
-	);
+	const available = audioPlayers.filter((player) => player.checkPlayable());
 
 	// eslint-disable-next-line @typescript-eslint/dot-notation
-	available.forEach((player) => player['_step']());
+	available.forEach((player) => player['_dispatchAll']());
+	// eslint-disable-next-line @typescript-eslint/dot-notation
+	available.forEach((player) => player['_prepareAll']());
 	audioCycleInterval = setTimeout(() => audioCycleStep(), nextTime - Date.now());
 }
 

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -144,8 +144,8 @@ export function deleteAudioPlayer(player: AudioPlayer) {
 	const index = audioPlayers.indexOf(player);
 	if (index === -1) return;
 	audioPlayers.splice(index, 1);
-	if (audioPlayers.length === 0 && typeof audioCycleInterval !== 'undefined') {
+	if (audioPlayers.length === 0) {
 		nextTime = -1;
-		clearTimeout(audioCycleInterval);
+		if (typeof audioCycleInterval !== 'undefined') clearTimeout(audioCycleInterval);
 	}
 }

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -131,6 +131,15 @@ export class AudioPlayer extends EventEmitter {
 	}
 
 	/**
+	 * A list of subscribed voice connections that can currently receive audio to play
+	 */
+	public get playable() {
+		return this.subscribers
+			.filter(({ connection }) => connection.state.status === VoiceConnectionStatus.Ready)
+			.map(({ connection }) => connection);
+	}
+
+	/**
 	 * Subscribes a VoiceConnection to the audio player's play list. If the VoiceConnection is already subscribed,
 	 * then the existing subscription is used.
 	 *
@@ -405,13 +414,8 @@ export class AudioPlayer extends EventEmitter {
 		// Guard against the Idle state
 		if (state.status === AudioPlayerStatus.Idle || state.status === AudioPlayerStatus.Buffering) return;
 
-		// List of connections that can receive the packet
-		const playable = this.subscribers
-			.filter(({ connection }) => connection.state.status === VoiceConnectionStatus.Ready)
-			.map(({ connection }) => connection);
-
 		// Dispatch any audio packets that were prepared in the previous cycle
-		playable.forEach((connection) => connection.dispatchAudio());
+		this.playable.forEach((connection) => connection.dispatchAudio());
 	}
 
 	private _prepareAll() {
@@ -421,9 +425,7 @@ export class AudioPlayer extends EventEmitter {
 		if (state.status === AudioPlayerStatus.Idle || state.status === AudioPlayerStatus.Buffering) return;
 
 		// List of connections that can receive the packet
-		const playable = this.subscribers
-			.filter(({ connection }) => connection.state.status === VoiceConnectionStatus.Ready)
-			.map(({ connection }) => connection);
+		const playable = this.playable;
 
 		/* If the player was previously in the AutoPaused state, check to see whether there are newly available
 		   connections, allowing us to transition out of the AutoPaused state back into the Playing state */

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -54,34 +54,42 @@ interface CreateAudioPlayerOptions {
 	};
 }
 
+interface IdleAudioPlayerState {
+	status: AudioPlayerStatus.Idle;
+}
+
+interface BufferingAudioPlayerState {
+	status: AudioPlayerStatus.Buffering;
+	resource: AudioResource;
+	onReadableCallback: () => void;
+	onFailureCallback: () => void;
+	onStreamError: (error: Error) => void;
+}
+
+interface PlayingAudioPlayerState {
+	status: AudioPlayerStatus.Playing;
+	missedFrames: number;
+	resource: AudioResource;
+	nextTime: number;
+	onStreamError: (error: Error) => void;
+}
+
+interface PausedAudioPlayerState {
+	status: AudioPlayerStatus.Paused | AudioPlayerStatus.AutoPaused;
+	silencePacketsRemaining: number;
+	resource: AudioResource;
+	nextTime: number;
+	onStreamError: (error: Error) => void;
+}
+
 /**
  * The various states that the player can be in.
  */
 type AudioPlayerState =
-	| {
-			status: AudioPlayerStatus.Idle;
-	  }
-	| {
-			status: AudioPlayerStatus.Buffering;
-			resource: AudioResource;
-			onReadableCallback: () => void;
-			onFailureCallback: () => void;
-			onStreamError: (error: Error) => void;
-	  }
-	| {
-			status: AudioPlayerStatus.Playing;
-			missedFrames: number;
-			resource: AudioResource;
-			nextTime: number;
-			onStreamError: (error: Error) => void;
-	  }
-	| {
-			status: AudioPlayerStatus.Paused | AudioPlayerStatus.AutoPaused;
-			silencePacketsRemaining: number;
-			resource: AudioResource;
-			nextTime: number;
-			onStreamError: (error: Error) => void;
-	  };
+	| IdleAudioPlayerState
+	| BufferingAudioPlayerState
+	| PlayingAudioPlayerState
+	| PausedAudioPlayerState;
 
 /**
  * Used to play audio resources (i.e. tracks, streams) to voice connections.

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -394,6 +394,11 @@ export class AudioPlayer extends EventEmitter {
 		return true;
 	}
 
+	/**
+	 * Checks whether the underlying resource (if any) is playable (readable).
+	 *
+	 * @returns true if the resource is playable, false otherwise.
+	 */
 	public checkPlayable() {
 		const state = this._state;
 		if (state.status === AudioPlayerStatus.Idle || state.status === AudioPlayerStatus.Buffering) return false;
@@ -408,7 +413,11 @@ export class AudioPlayer extends EventEmitter {
 		return true;
 	}
 
-	private _dispatchAll() {
+	/**
+	 * Called roughly every 20ms by the global audio player timer. Dispatches any audio packets that are buffered
+	 * by the active connections of this audio player.
+	 */
+	private _stepDispatch() {
 		const state = this._state;
 
 		// Guard against the Idle state
@@ -418,7 +427,12 @@ export class AudioPlayer extends EventEmitter {
 		this.playable.forEach((connection) => connection.dispatchAudio());
 	}
 
-	private _prepareAll() {
+	/**
+	 * Called roughly every 20ms by the global audio player timer. Attempts to read an audio packet from the
+	 * underlying resource of the stream, and then has all the active connections of the audio player prepare it
+	 * (encrypt it, append header data) so that it is ready to play at the start of the next cycle.
+	 */
+	private _stepPrepare() {
 		const state = this._state;
 
 		// Guard against the Idle state

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -232,7 +232,7 @@ export class AudioPlayer extends EventEmitter {
 			deleteAudioPlayer(this);
 		}
 
-		// do the thing
+		// attach to the global audio player timer
 		if (newResource) {
 			addAudioPlayer(this);
 		}

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -51,40 +51,32 @@ interface CreateAudioPlayerOptions {
 	};
 }
 
-interface IdleAudioPlayerState {
-	status: AudioPlayerStatus.Idle;
-}
-
-interface BufferingAudioPlayerState {
-	status: AudioPlayerStatus.Buffering;
-	resource: AudioResource;
-	onReadableCallback: () => void;
-	onFailureCallback: () => void;
-	onStreamError: (error: Error) => void;
-}
-
-interface PlayingAudioPlayerState {
-	status: AudioPlayerStatus.Playing;
-	missedFrames: number;
-	resource: AudioResource;
-	onStreamError: (error: Error) => void;
-}
-
-interface PausedAudioPlayerState {
-	status: AudioPlayerStatus.Paused | AudioPlayerStatus.AutoPaused;
-	silencePacketsRemaining: number;
-	resource: AudioResource;
-	onStreamError: (error: Error) => void;
-}
-
 /**
  * The various states that the player can be in.
  */
 type AudioPlayerState =
-	| IdleAudioPlayerState
-	| BufferingAudioPlayerState
-	| PlayingAudioPlayerState
-	| PausedAudioPlayerState;
+	| {
+			status: AudioPlayerStatus.Idle;
+	  }
+	| {
+			status: AudioPlayerStatus.Buffering;
+			resource: AudioResource;
+			onReadableCallback: () => void;
+			onFailureCallback: () => void;
+			onStreamError: (error: Error) => void;
+	  }
+	| {
+			status: AudioPlayerStatus.Playing;
+			missedFrames: number;
+			resource: AudioResource;
+			onStreamError: (error: Error) => void;
+	  }
+	| {
+			status: AudioPlayerStatus.Paused | AudioPlayerStatus.AutoPaused;
+			silencePacketsRemaining: number;
+			resource: AudioResource;
+			onStreamError: (error: Error) => void;
+	  };
 
 /**
  * Used to play audio resources (i.e. tracks, streams) to voice connections.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #53.

Audio players are no longer responsible for their own timing cycles. Instead, they now subscribe to a global timer in the `DataStore`.

When players enter the `Playing` state, they attach themselves to this timer. When they enter the `Idle` state, they detach themselves.

While there are no players attached, the timer is unset and therefore doesn't block the process from exiting.

The timer runs roughly every 20ms while active. At the start of each interval, it has all the active voice connections under the audio players dispatch any buffered audio packets. After this is done, each audio player takes turns in preparing their next audio frame for each of their own voice connections (this is the CPU intensive part that will ideally be reduced in the future).

This means that assuming the user isn't doing any CPU-intensive task that blocks the event loop, stuttering should be greatly reduced when using more than one audio player.

Again, this doesn't really remove any blocking tasks from the event loop. Instead, it restructures the order in which they are called to ensure that audio frames are dispatched as consistently as possible.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes