### PR TITLE
fix(VoiceConnection): improve recoverability

### DIFF
--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -74,8 +74,9 @@ export class VoiceConnection extends EventEmitter {
 
 	/**
 	 * A configuration storing all the data needed to reconnect to a Guild's voice server.
+	 * @internal
 	 */
-	private readonly joinConfig: JoinConfig;
+	public readonly joinConfig: JoinConfig;
 
 	/**
 	 * The two packets needed to successfully establish a voice connection. They are received
@@ -222,6 +223,7 @@ export class VoiceConnection extends EventEmitter {
 		networking.on('debug', this.onNetworkingDebug);
 
 		this.state = {
+			...this.state,
 			status: VoiceConnectionStatus.Connecting,
 			networking,
 		};
@@ -243,11 +245,15 @@ export class VoiceConnection extends EventEmitter {
 		if (code === 4014) {
 			// Disconnected - networking is already destroyed here
 			this.state = {
+				...this.state,
 				status: VoiceConnectionStatus.Disconnected,
 				closeCode: code,
 			};
 		} else {
-			this.state = { status: VoiceConnectionStatus.Signalling };
+			this.state = {
+				...this.state,
+				status: VoiceConnectionStatus.Signalling,
+			};
 			signalJoinVoiceChannel(this.joinConfig);
 		}
 	}
@@ -362,6 +368,7 @@ export class VoiceConnection extends EventEmitter {
 		this.reconnectAttempts++;
 
 		this.state = {
+			...this.state,
 			status: VoiceConnectionStatus.Signalling,
 		};
 		return true;
@@ -420,10 +427,6 @@ export class VoiceConnection extends EventEmitter {
 export function createVoiceConnection(joinConfig: JoinConfig, options: JoinVoiceChannelOptions) {
 	const existing = getVoiceConnection(joinConfig.guild.id);
 	if (existing) {
-		existing.state = {
-			...existing.state,
-			status: VoiceConnectionStatus.Signalling,
-		};
 		signalJoinVoiceChannel(joinConfig);
 		return existing;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Two bugs were introduced in recent changes:

1. Subscriptions were silently removed whenever the voice connection disconnected. That means when they recovered, they would no longer be subscribed to an audio player.
2. An incorrect assumption was made about what happens when signalling to join a voice channel that the client is already connected to. It is not always the case that a voice server switch is required. Therefore, a Voice Connection will no longer transition to the `Signalling` state when `joinVoiceChannel` is called repeatedly. The packet will still be sent, but a reconnect will only occur if a `VOICE_SERVER_UPDATE` packet is received.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
