### PR TITLE
feat(AudioPlayer): add maxMissedFrames behaviour

### DIFF
--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -473,7 +473,7 @@ export class AudioPlayer extends EventEmitter {
 			} else {
 				this._preparePacket(SILENCE_FRAME, playable);
 				state.missedFrames++;
-				if (state.missedFrames >= 5) {
+				if (state.missedFrames >= this.behaviours.maxMissedFrames) {
 					this.stop();
 				}
 			}

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -50,6 +50,7 @@ interface CreateAudioPlayerOptions {
 	debug?: boolean;
 	behaviours?: {
 		noSubscriber?: NoSubscriberBehaviour;
+		maxMissedFrames?: number;
 	};
 }
 
@@ -108,6 +109,7 @@ export class AudioPlayer extends EventEmitter {
 	 */
 	private readonly behaviours: {
 		noSubscriber: NoSubscriberBehaviour;
+		maxMissedFrames: number;
 	};
 
 	/**
@@ -123,6 +125,7 @@ export class AudioPlayer extends EventEmitter {
 		this._state = { status: AudioPlayerStatus.Idle };
 		this.behaviours = {
 			noSubscriber: NoSubscriberBehaviour.Pause,
+			maxMissedFrames: 5,
 			...options.behaviours,
 		};
 		this.debug = options.debug === false ? null : this.emit.bind(this, 'debug');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #57.

Allows users to specify `maxMissedFrames` when creating an audio player:

```ts
createAudioPlayer({
  behaviours: {
    maxMissedFrames: 5 // default
  }
});
```

Each frame is equivalent to 20ms of audio - the default value is therefore 100ms.

You could set this to `Infinity` to disable playback when there are gaps in streams. Useful when you know you will be playing a stream with many gaps in it (e.g. streams that omit silence)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
