### PR TITLE
feat: generality

### DIFF
--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -24,17 +24,17 @@ export interface JoinConfig {
 }
 
 // Voice Connections
-const voiceConnections: Map<string, VoiceConnection> = new Map();
+const voiceConnections: Map<Snowflake, VoiceConnection> = new Map();
 
-export function getVoiceConnection(guildId: string) {
+export function getVoiceConnection(guildId: Snowflake) {
 	return voiceConnections.get(guildId);
 }
 
-export function untrackVoiceConnection(guildId: string) {
+export function untrackVoiceConnection(guildId: Snowflake) {
 	return voiceConnections.delete(guildId);
 }
 
-export function trackVoiceConnection(guildId: string, voiceConnection: VoiceConnection) {
+export function trackVoiceConnection(guildId: Snowflake, voiceConnection: VoiceConnection) {
 	return voiceConnections.set(guildId, voiceConnection);
 }
 

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -1,3 +1,4 @@
+import { Snowflake } from 'discord-api-types/v8';
 import {
 	GatewayVoiceServerUpdateDispatchData,
 	GatewayVoiceStateUpdateDispatchData,
@@ -16,8 +17,8 @@ export function handleVoiceStateUpdate(payload: GatewayVoiceStateUpdateDispatchD
 }
 
 export interface JoinConfig {
-	guildId: string;
-	channelId: string | null;
+	guildId: Snowflake;
+	channelId: Snowflake | null;
 	selfDeaf: boolean;
 	selfMute: boolean;
 }

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -2,6 +2,7 @@ import {
 	GatewayOPCodes,
 	GatewayVoiceServerUpdateDispatchData,
 	GatewayVoiceStateUpdateDispatchData,
+	Snowflake,
 } from 'discord-api-types/v8';
 import { EventEmitter } from 'events';
 import { JoinVoiceChannelOptions } from '.';
@@ -74,8 +75,8 @@ export enum VoiceConnectionEvents {
 export interface SignalJoinVoiceChannelPayload {
 	op: GatewayOPCodes.VoiceStateUpdate;
 	d: {
-		guild_id: string;
-		channel_id: string | null;
+		guild_id: Snowflake;
+		channel_id: Snowflake | null;
 		self_deaf: boolean;
 		self_mute: boolean;
 	};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,6 @@ export * from './joinVoiceChannel';
 export * from './audio';
 export * from './util';
 
-export { VoiceConnection, VoiceConnectionState, VoiceConnectionStatus } from './VoiceConnection';
+export { VoiceConnection, VoiceConnectionState, VoiceConnectionStatus, VoiceConnectionEvents } from './VoiceConnection';
 
-export { getVoiceConnection } from './DataStore';
+export { getVoiceConnection, handleVoiceServerUpdate, handleVoiceStateUpdate } from './DataStore';

--- a/src/joinVoiceChannel.ts
+++ b/src/joinVoiceChannel.ts
@@ -1,4 +1,3 @@
-import { VoiceChannel } from 'discord.js';
 import { createVoiceConnection } from './VoiceConnection';
 import { JoinConfig } from './DataStore';
 
@@ -6,6 +5,14 @@ import { JoinConfig } from './DataStore';
  * The options that can be given when joining a voice channel
  */
 export interface JoinVoiceChannelOptions {
+	/**
+	 * The ID of the voice channel to join
+	 */
+	channelId: string;
+	/**
+	 * The ID of the guild the voice channel belongs to
+	 */
+	guildId: string;
 	/**
 	 * If true, debug messages will be enabled for the voice connection and its
 	 * related components. Defaults to false.
@@ -19,10 +26,10 @@ export interface JoinVoiceChannelOptions {
  * @param voiceChannel - the voice channel to connect to
  * @param options - the options for joining the voice channel
  */
-export function joinVoiceChannel(voiceChannel: VoiceChannel, options?: JoinVoiceChannelOptions) {
+export function joinVoiceChannel(options: JoinVoiceChannelOptions) {
 	const joinConfig: JoinConfig = {
-		channelId: voiceChannel.id,
-		guild: voiceChannel.guild,
+		channelId: options.channelId,
+		guildId: options.guildId,
 		selfDeaf: true,
 		selfMute: false,
 	};

--- a/src/joinVoiceChannel.ts
+++ b/src/joinVoiceChannel.ts
@@ -7,13 +7,13 @@ import { Snowflake } from 'discord-api-types/v8';
  */
 export interface JoinVoiceChannelOptions {
 	/**
-	 * The ID of the voice channel to join
-	 */
-	channelId: Snowflake;
-	/**
 	 * The ID of the guild the voice channel belongs to
 	 */
 	guildId: Snowflake;
+	/**
+	 * The ID of the voice channel to join
+	 */
+	channelId: Snowflake;
 	/**
 	 * If true, debug messages will be enabled for the voice connection and its
 	 * related components. Defaults to false.

--- a/src/joinVoiceChannel.ts
+++ b/src/joinVoiceChannel.ts
@@ -1,5 +1,6 @@
 import { createVoiceConnection } from './VoiceConnection';
 import { JoinConfig } from './DataStore';
+import { Snowflake } from 'discord-api-types/v8';
 
 /**
  * The options that can be given when joining a voice channel
@@ -8,11 +9,11 @@ export interface JoinVoiceChannelOptions {
 	/**
 	 * The ID of the voice channel to join
 	 */
-	channelId: string;
+	channelId: Snowflake;
 	/**
 	 * The ID of the guild the voice channel belongs to
 	 */
-	guildId: string;
+	guildId: Snowflake;
 	/**
 	 * If true, debug messages will be enabled for the voice connection and its
 	 * related components. Defaults to false.

--- a/src/util/entersState.ts
+++ b/src/util/entersState.ts
@@ -1,13 +1,13 @@
 import { VoiceConnection, VoiceConnectionStatus } from '../VoiceConnection';
 import { AudioPlayer, AudioPlayerStatus } from '../audio/AudioPlayer';
 
-export function entersState(
-	target: VoiceConnection,
-	status: VoiceConnectionStatus,
-	maxTime: number,
-): Promise<VoiceConnection>;
+// export function entersState(
+// 	target: VoiceConnection,
+// 	status: VoiceConnectionStatus,
+// 	maxTime: number,
+// ): Promise<VoiceConnection>;
 
-export function entersState(target: AudioPlayer, status: AudioPlayerStatus, maxTime: number): Promise<AudioPlayer>;
+// export function entersState(target: AudioPlayer, status: AudioPlayerStatus, maxTime: number): Promise<AudioPlayer>;
 
 /**
  * Allows a target a specified amount of time to enter a given state, otherwise rejects with an error.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR makes voice more generic and removes dependence on Discord.js.

`trackClient` accepted a Client; it was removed and replaced with `handleVoiceServerUpdate` and `handleVoiceStateUpdate`
Eg:
```ts  
client.ws.on('VOICE_SERVER_UPDATE', handleVoiceServerUpdate);
client.ws.on('VOICE_STATE_UPDATE', (payload) => handleVoiceStateUpdate(payload, process.env.CLIENT_ID!));
```

Previously, `signalJoinVoiceChannel` sent a payload directly to the socket corresponding to the passed Guild class.
It was replaced with `VoiceConnection#signalJoinVoiceChannel`, which emits `joinVoiceChannel`. Now, users are responsible for handling that event:
```ts
const connection = joinVoiceChannel({ guildId: channel.guild.id, channelId: channel.id });
connection.on(VoiceConnectionEvents.JoinVoiceChannel, (payload) => {
	console.log(payload);
	channel.guild.shard.send(payload);
});
connection.connect();
```
The above code example looks messy and unnecessarily verbose. That's because the previous implementation of `signalJoinVoiceChannel`, the `VOICE_STATE_UPDATE` packet was sent within `joinVoiceChannel`. Now that users are required to send the payload manually, we had to remove that line from `joinVoiceChannel`.
`VoiceConnection#connect` is just a public helper for `VoiceConnection#signalJoinVoiceChannel`

One idea that came to mind for cleaning up that catastrophe would be to declare a `handleJoinPayload` function on `JoinConfig`:
```ts
joinVoiceChannel({
	guildId: channel.guild.id,
	channelId: channel.id,
	handleJoinPayload: (payload) => channel.guild.shard.send(payload),
});
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

Closes #64