### PR TITLE
feat!: implement adapters

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -22,6 +22,7 @@ import {
 	AudioPlayerStatus,
 	VoiceConnectionStatus,
 } from '@discordjs/voice';
+import { createDiscordJSAdapter } from './adapter';
 
 const player = createAudioPlayer();
 
@@ -36,7 +37,11 @@ function playSong() {
 }
 
 async function connectToChannel(channel: VoiceChannel) {
-	const connection = joinVoiceChannel(channel);
+	const connection = joinVoiceChannel({
+		channelId: channel.id,
+		guildId: channel.guild.id,
+		adapterCreator: createDiscordJSAdapter(channel),
+	});
 
 	try {
 		await entersState(connection, VoiceConnectionStatus.Ready, 30e3);

--- a/examples/basic/adapter.ts
+++ b/examples/basic/adapter.ts
@@ -1,0 +1,45 @@
+import { DiscordGatewayAdapterCreator, DiscordGatewayAdapterLibraryMethods } from '../../';
+import { VoiceChannel, Snowflake, Client, Constants } from 'discord.js';
+import {
+	GatewayVoiceServerUpdateDispatchData,
+	GatewayVoiceStateUpdateDispatchData,
+} from 'discord-api-types/v8/gateway';
+
+const adapters = new Map<Snowflake, DiscordGatewayAdapterLibraryMethods>();
+const trackedClients = new Set<Client>();
+
+/**
+ * Tracks a Discord.js client, listening to VOICE_SERVER_UPDATE and VOICE_STATE_UPDATE events.
+ * @param client The Discord.js Client to track
+ */
+function trackClient(client: Client) {
+	if (trackedClients.has(client)) return;
+	trackedClients.add(client);
+	client.ws.on(Constants.WSEvents.VOICE_SERVER_UPDATE, (payload: GatewayVoiceServerUpdateDispatchData) => {
+		adapters.get(payload.guild_id)?.onVoiceServerUpdate(payload);
+	});
+	client.ws.on(Constants.WSEvents.VOICE_STATE_UPDATE, (payload: GatewayVoiceStateUpdateDispatchData) => {
+		if (payload.guild_id && payload.session_id && payload.user_id === client.user?.id) {
+			adapters.get(payload.guild_id)?.onVoiceStateUpdate(payload);
+		}
+	});
+}
+
+/**
+ * Creates an adapter for a Voice Channel
+ * @param channel The channel to create the adapter for
+ */
+export function createDiscordJSAdapter(channel: VoiceChannel): DiscordGatewayAdapterCreator {
+	return (methods) => {
+		adapters.set(channel.guild.id, methods);
+		trackClient(channel.client);
+		return {
+			sendPayload(data) {
+				return channel.guild.shard.send(data);
+			},
+			destroy() {
+				return adapters.delete(channel.guild.id);
+			},
+		};
+	};
+}

--- a/examples/basic/basic-example.ts
+++ b/examples/basic/basic-example.ts
@@ -10,6 +10,7 @@ import {
 	AudioPlayerStatus,
 	VoiceConnectionStatus,
 } from '@discordjs/voice';
+import { createDiscordJSAdapter } from './adapter';
 
 /*
 	In this example, we are creating a single audio player that plays to a number of
@@ -57,7 +58,11 @@ async function connectToChannel(channel: VoiceChannel) {
 		to this voice channel, @discordjs/voice will just return the existing connection for
 		us!
 	*/
-	const connection = joinVoiceChannel(channel);
+	const connection = joinVoiceChannel({
+		channelId: channel.id,
+		guildId: channel.guild.id,
+		adapterCreator: createDiscordJSAdapter(channel),
+	});
 
 	/*
 		If we're dealing with a connection that isn't yet Ready, we can set a reasonable

--- a/package-lock.json
+++ b/package-lock.json
@@ -254,23 +254,6 @@
 			"integrity": "sha512-VoNqai1vR5anRF5Tuh/+SWDFk7xi7oMwHrHrbm1BprYXjB2RJsWLhUrStMssDxEl5lW/z3EUdg8RvH/IUBccSQ==",
 			"dev": true
 		},
-		"@discordjs/collection": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
-			"integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ==",
-			"dev": true
-		},
-		"@discordjs/form-data": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/form-data/-/form-data-3.0.1.tgz",
-			"integrity": "sha512-ZfFsbgEXW71Rw/6EtBdrP5VxBJy4dthyC0tpQKGKmYFImlmmrykO14Za+BiIVduwjte0jXEBlhSKf0MWbFp9Eg==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			}
-		},
 		"@eslint/eslintrc": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
@@ -448,15 +431,6 @@
 				"through": ">=2.2.7 <3"
 			}
 		},
-		"abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"dev": true,
-			"requires": {
-				"event-target-shim": "^5.0.0"
-			}
-		},
 		"acorn": {
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -560,12 +534,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-			"dev": true
-		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
 		},
 		"at-least-node": {
@@ -804,15 +772,6 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
-		"combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
-		},
 		"commander": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -953,12 +912,6 @@
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
 			"dev": true
 		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
-		},
 		"dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -973,22 +926,6 @@
 			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.12.1.tgz",
 			"integrity": "sha512-x8dhQqPZUtIEKjDHMdA6D3aAsZUMoeo58fAgFA5WOAdSh+uVyRsvny4+25b+RIRasG2Zf2UpDUsx8NKO5zk/6g==",
 			"dev": true
-		},
-		"discord.js": {
-			"version": "12.5.1",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.5.1.tgz",
-			"integrity": "sha512-VwZkVaUAIOB9mKdca0I5MefPMTQJTNg0qdgi1huF3iwsFwJ0L5s/Y69AQe+iPmjuV6j9rtKoG0Ta0n9vgEIL6w==",
-			"dev": true,
-			"requires": {
-				"@discordjs/collection": "^0.1.6",
-				"@discordjs/form-data": "^3.0.1",
-				"abort-controller": "^3.0.0",
-				"node-fetch": "^2.6.1",
-				"prism-media": "^1.2.2",
-				"setimmediate": "^1.0.5",
-				"tweetnacl": "^1.0.3",
-				"ws": "^7.3.1"
-			}
 		},
 		"doctrine": {
 			"version": "3.0.0",
@@ -1224,12 +1161,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
-		},
-		"event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
 			"dev": true
 		},
 		"execa": {
@@ -1948,21 +1879,6 @@
 				"picomatch": "^2.0.5"
 			}
 		},
-		"mime-db": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-			"integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
-			"dev": true
-		},
-		"mime-types": {
-			"version": "2.1.28",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-			"integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
-			"dev": true,
-			"requires": {
-				"mime-db": "1.45.0"
-			}
-		},
 		"mimic-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -2005,12 +1921,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-			"dev": true
-		},
-		"node-fetch": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
 			"dev": true
 		},
 		"normalize-package-data": {
@@ -2495,12 +2405,6 @@
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true
 		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
-		},
 		"shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2832,12 +2736,6 @@
 			"requires": {
 				"tslib": "^1.8.1"
 			}
-		},
-		"tweetnacl": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-			"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-			"dev": true
 		},
 		"type-check": {
 			"version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1048,12 +1048,12 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.19.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.19.0.tgz",
-			"integrity": "sha512-CGlMgJY56JZ9ZSYhJuhow61lMPPjUzWmChFya71Z/jilVos7mR/jPgaEfVGgMBY5DshbKdG8Ezb8FDCHcoMEMg==",
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
+			"integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
+				"@babel/code-frame": "7.12.11",
 				"@eslint/eslintrc": "^0.3.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
@@ -1065,7 +1065,7 @@
 				"eslint-utils": "^2.1.0",
 				"eslint-visitor-keys": "^2.0.0",
 				"espree": "^7.3.1",
-				"esquery": "^1.2.0",
+				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^6.0.0",
 				"functional-red-black-tree": "^1.0.1",
@@ -1181,9 +1181,9 @@
 			"dev": true
 		},
 		"esquery": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-			"integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.1.0"
@@ -1306,9 +1306,9 @@
 			}
 		},
 		"file-entry-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
-			"integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
 			"requires": {
 				"flat-cache": "^3.0.4"
@@ -1353,9 +1353,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
-			"integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
 			"dev": true
 		},
 		"fs-extra": {
@@ -2751,9 +2751,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "7.0.4",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.4.tgz",
-					"integrity": "sha512-xzzzaqgEQfmuhbhAoqjJ8T/1okb6gAzXn/eQRNpAN1AEUoHJTNF9xCDRTtf/s3SKldtZfa+RJeTs+BQq+eZ/sw==",
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.1.tgz",
+					"integrity": "sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -2855,9 +2855,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.2.0-dev.20210204",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.0-dev.20210204.tgz",
-			"integrity": "sha512-mskEzzg8xT6dqZmmRvV27Ktabr79FxJ/nWhSVW2ERkuZHk//IeBkLdXGCUAbB170uAGMr8Izk4U/Lxl0EvRnaA==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
+			"integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
 			"dev": true
 		},
 		"universalify": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
 		"@typescript-eslint/eslint-plugin": "^4.14.2",
 		"@typescript-eslint/parser": "^4.14.2",
 		"discord-api-types": "^0.12.1",
-		"discord.js": "^12.5.1",
 		"eslint": "^7.20.0",
 		"eslint-config-marine": "^8.1.0",
 		"eslint-config-prettier": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
 		"@typescript-eslint/parser": "^4.14.2",
 		"discord-api-types": "^0.12.1",
 		"discord.js": "^12.5.1",
-		"eslint": "^7.19.0",
+		"eslint": "^7.20.0",
 		"eslint-config-marine": "^8.1.0",
 		"eslint-config-prettier": "^7.2.0",
 		"eslint-plugin-prettier": "^3.3.1",
 		"husky": "^4.3.8",
 		"lint-staged": "^10.5.4",
 		"prettier": "^2.2.1",
-		"typescript": "^4.2.0-dev.20210204"
+		"typescript": "^4.2.2"
 	},
 	"husky": {
 		"hooks": {

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -1,12 +1,12 @@
+import { Snowflake } from 'discord-api-types/v8';
 import { GatewayOPCodes } from 'discord-api-types/v8/gateway';
-import { Guild } from 'discord.js';
 import { AudioPlayer } from './audio';
 import { DiscordGatewayAdapter } from './joinVoiceChannel';
 import { VoiceConnection } from './VoiceConnection';
 
 export interface JoinConfig {
-	guild: Guild;
-	channelId: string | null;
+	guildId: Snowflake;
+	channelId: Snowflake | null;
 	selfDeaf: boolean;
 	selfMute: boolean;
 }
@@ -21,7 +21,7 @@ export function signalJoinVoiceChannel(config: JoinConfig, adapter: DiscordGatew
 	return adapter.sendPayload({
 		op: GatewayOPCodes.VoiceStateUpdate,
 		d: {
-			guild_id: config.guild.id,
+			guild_id: config.guildId,
 			channel_id: config.channelId,
 			self_deaf: config.selfDeaf,
 			self_mute: config.selfMute,

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -1,7 +1,6 @@
 import { Snowflake } from 'discord-api-types/v8';
 import { GatewayOPCodes } from 'discord-api-types/v8/gateway';
 import { AudioPlayer } from './audio';
-import { DiscordGatewayAdapter } from './joinVoiceChannel';
 import { VoiceConnection } from './VoiceConnection';
 
 export interface JoinConfig {
@@ -17,8 +16,8 @@ export interface JoinConfig {
  *
  * @param config - The configuration to use when joining the voice channel
  */
-export function signalJoinVoiceChannel(config: JoinConfig, adapter: DiscordGatewayAdapter) {
-	return adapter.sendPayload({
+export function createJoinVoiceChannelPayload(config: JoinConfig) {
+	return {
 		op: GatewayOPCodes.VoiceStateUpdate,
 		d: {
 			guild_id: config.guildId,
@@ -26,7 +25,7 @@ export function signalJoinVoiceChannel(config: JoinConfig, adapter: DiscordGatew
 			self_deaf: config.selfDeaf,
 			self_mute: config.selfMute,
 		},
-	});
+	};
 }
 
 // Voice Connections

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -5,6 +5,7 @@ import {
 } from 'discord-api-types/v8/gateway';
 import { Client, Constants, Guild } from 'discord.js';
 import { AudioPlayer } from './audio';
+import { DiscordGatewayAdapter } from './joinVoiceChannel';
 import { VoiceConnection } from './VoiceConnection';
 
 // Clients
@@ -39,8 +40,8 @@ export interface JoinConfig {
  *
  * @param config - The configuration to use when joining the voice channel
  */
-export function signalJoinVoiceChannel(config: JoinConfig) {
-	return config.guild.shard.send({
+export function signalJoinVoiceChannel(config: JoinConfig, adapter: DiscordGatewayAdapter) {
+	return adapter.sendPayload({
 		op: GatewayOPCodes.VoiceStateUpdate,
 		d: {
 			guild_id: config.guild.id,

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -1,31 +1,8 @@
-import {
-	GatewayOPCodes,
-	GatewayVoiceServerUpdateDispatchData,
-	GatewayVoiceStateUpdateDispatchData,
-} from 'discord-api-types/v8/gateway';
-import { Client, Constants, Guild } from 'discord.js';
+import { GatewayOPCodes } from 'discord-api-types/v8/gateway';
+import { Guild } from 'discord.js';
 import { AudioPlayer } from './audio';
 import { DiscordGatewayAdapter } from './joinVoiceChannel';
 import { VoiceConnection } from './VoiceConnection';
-
-// Clients
-const clients: Set<Client> = new Set();
-export function trackClient(client: Client) {
-	if (clients.has(client)) {
-		return;
-	}
-	clients.add(client);
-
-	client.ws.on(Constants.WSEvents.VOICE_SERVER_UPDATE, (payload: GatewayVoiceServerUpdateDispatchData) => {
-		getVoiceConnection(payload.guild_id)?.addServerPacket(payload);
-	});
-
-	client.ws.on(Constants.WSEvents.VOICE_STATE_UPDATE, (payload: GatewayVoiceStateUpdateDispatchData) => {
-		if (payload.guild_id && payload.session_id && payload.user_id === client.user?.id) {
-			getVoiceConnection(payload.guild_id)?.addStatePacket(payload);
-		}
-	});
-}
 
 export interface JoinConfig {
 	guild: Guild;

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -1,11 +1,10 @@
-import { Snowflake } from 'discord-api-types/v8';
 import { GatewayOPCodes } from 'discord-api-types/v8/gateway';
 import { AudioPlayer } from './audio';
 import { VoiceConnection } from './VoiceConnection';
 
 export interface JoinConfig {
-	guildId: Snowflake;
-	channelId: Snowflake | null;
+	guildId: string;
+	channelId: string | null;
 	selfDeaf: boolean;
 	selfMute: boolean;
 }

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -1,6 +1,6 @@
 import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v8';
 import { EventEmitter } from 'events';
-import { JoinVoiceChannelOptions } from '.';
+import { CreateVoiceConnectionOptions } from '.';
 import { AudioPlayer } from './audio/AudioPlayer';
 import { PlayerSubscription } from './audio/PlayerSubscription';
 import {
@@ -101,7 +101,7 @@ export class VoiceConnection extends EventEmitter {
 	 *
 	 * @param joinConfig - The data required to establish the voice connection
 	 */
-	public constructor(joinConfig: JoinConfig, { debug, adapter }: JoinVoiceChannelOptions) {
+	public constructor(joinConfig: JoinConfig, { debug, adapter }: CreateVoiceConnectionOptions) {
 		super();
 
 		this.debug = debug ? this.emit.bind(this, 'debug') : null;
@@ -355,8 +355,8 @@ export class VoiceConnection extends EventEmitter {
 		if (this.state.status === VoiceConnectionStatus.Destroyed) {
 			throw new Error('Cannot destroy VoiceConnection - it has already been destroyed');
 		}
-		if (getVoiceConnection(this.joinConfig.guild.id) === this) {
-			untrackVoiceConnection(this.joinConfig.guild.id);
+		if (getVoiceConnection(this.joinConfig.guildId) === this) {
+			untrackVoiceConnection(this.joinConfig.guildId);
 		}
 		signalJoinVoiceChannel(
 			{
@@ -447,8 +447,8 @@ export class VoiceConnection extends EventEmitter {
  * @param joinConfig - The data required to establish the voice connection
  * @param options - The options to use when joining the voice channel
  */
-export function createVoiceConnection(joinConfig: JoinConfig, options: JoinVoiceChannelOptions) {
-	const existing = getVoiceConnection(joinConfig.guild.id);
+export function createVoiceConnection(joinConfig: JoinConfig, options: CreateVoiceConnectionOptions) {
+	const existing = getVoiceConnection(joinConfig.guildId);
 	if (existing && existing.state.status !== VoiceConnectionStatus.Destroyed) {
 		// The new adapter hasn't actually been accepted, so it can be destroyed
 		options.adapter.destroy?.();
@@ -457,7 +457,7 @@ export function createVoiceConnection(joinConfig: JoinConfig, options: JoinVoice
 	}
 
 	const voiceConnection = new VoiceConnection(joinConfig, options);
-	trackVoiceConnection(joinConfig.guild.id, voiceConnection);
+	trackVoiceConnection(joinConfig.guildId, voiceConnection);
 	signalJoinVoiceChannel(joinConfig, options.adapter);
 
 	return voiceConnection;

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -6,7 +6,6 @@ import { PlayerSubscription } from './audio/PlayerSubscription';
 import {
 	getVoiceConnection,
 	signalJoinVoiceChannel,
-	trackClient,
 	trackVoiceConnection,
 	JoinConfig,
 	untrackVoiceConnection,
@@ -459,7 +458,6 @@ export function createVoiceConnection(joinConfig: JoinConfig, options: JoinVoice
 
 	const voiceConnection = new VoiceConnection(joinConfig, options);
 	trackVoiceConnection(joinConfig.guild.id, voiceConnection);
-	trackClient(joinConfig.guild.client);
 	signalJoinVoiceChannel(joinConfig, options.adapter);
 
 	return voiceConnection;

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -113,6 +113,9 @@ export class VoiceConnection extends EventEmitter {
 		this.onNetworkingError = this.onNetworkingError.bind(this);
 		this.onNetworkingDebug = this.onNetworkingDebug.bind(this);
 
+		adapter.on('voiceServerUpdate', (packet: GatewayVoiceServerUpdateDispatchData) => this.addServerPacket(packet));
+		adapter.on('voiceStateUpdate', (packet: GatewayVoiceStateUpdateDispatchData) => this.addStatePacket(packet));
+
 		this._state = { status: VoiceConnectionStatus.Signalling, adapter };
 
 		this.packets = {
@@ -177,7 +180,7 @@ export class VoiceConnection extends EventEmitter {
 	 *
 	 * @param packet - The received `VOICE_SERVER_UPDATE` packet
 	 */
-	public addServerPacket(packet: GatewayVoiceServerUpdateDispatchData) {
+	private addServerPacket(packet: GatewayVoiceServerUpdateDispatchData) {
 		this.packets.server = packet;
 		this.configureNetworking();
 	}
@@ -188,7 +191,7 @@ export class VoiceConnection extends EventEmitter {
 	 *
 	 * @param packet - The received `VOICE_STATE_UPDATE` packet
 	 */
-	public addStatePacket(packet: GatewayVoiceStateUpdateDispatchData) {
+	private addStatePacket(packet: GatewayVoiceStateUpdateDispatchData) {
 		this.packets.state = packet;
 
 		if (typeof packet.self_deaf !== 'undefined') this.joinConfig.selfDeaf = packet.self_deaf;

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -159,7 +159,7 @@ export class VoiceConnection extends EventEmitter {
 		}
 
 		// If destroyed, the adapter can also be destroyed so it can be cleaned up by the user
-		if (oldState.status !== VoiceConnectionStatus.Destroyed) {
+		if (oldState.status !== VoiceConnectionStatus.Destroyed && newState.status === VoiceConnectionStatus.Destroyed) {
 			oldState.adapter.destroy?.();
 		}
 

--- a/src/joinVoiceChannel.ts
+++ b/src/joinVoiceChannel.ts
@@ -1,7 +1,10 @@
-import { VoiceChannel } from 'discord.js';
 import { createVoiceConnection } from './VoiceConnection';
 import { JoinConfig } from './DataStore';
-import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v8';
+import {
+	GatewayVoiceServerUpdateDispatchData,
+	GatewayVoiceStateUpdateDispatchData,
+	Snowflake,
+} from 'discord-api-types/v8';
 import { EventEmitter } from 'events';
 
 interface DiscordGatewayAdapterEvents {
@@ -27,7 +30,7 @@ export abstract class DiscordGatewayAdapter extends EventEmitter implements Disc
 /**
  * The options that can be given when joining a voice channel
  */
-export interface JoinVoiceChannelOptions {
+export interface CreateVoiceConnectionOptions {
 	/**
 	 * If true, debug messages will be enabled for the voice connection and its
 	 * related components. Defaults to false.
@@ -36,19 +39,27 @@ export interface JoinVoiceChannelOptions {
 	adapter: DiscordGatewayAdapter;
 }
 
+export interface JoinVoiceChannelOptions {
+	channelId: Snowflake;
+	guildId: Snowflake;
+}
+
 /**
  * Creates a VoiceConnection to a Discord.js Voice Channel.
  *
  * @param voiceChannel - the voice channel to connect to
  * @param options - the options for joining the voice channel
  */
-export function joinVoiceChannel(voiceChannel: VoiceChannel, options: JoinVoiceChannelOptions) {
+export function joinVoiceChannel(options: JoinVoiceChannelOptions & CreateVoiceConnectionOptions) {
 	const joinConfig: JoinConfig = {
-		channelId: voiceChannel.id,
-		guild: voiceChannel.guild,
+		channelId: options.channelId,
+		guildId: options.guildId,
 		selfDeaf: true,
 		selfMute: false,
 	};
 
-	return createVoiceConnection(joinConfig, { debug: false, ...options });
+	return createVoiceConnection(joinConfig, {
+		adapter: options.adapter,
+		debug: options.debug,
+	});
 }

--- a/src/joinVoiceChannel.ts
+++ b/src/joinVoiceChannel.ts
@@ -1,31 +1,7 @@
 import { createVoiceConnection } from './VoiceConnection';
 import { JoinConfig } from './DataStore';
-import {
-	GatewayVoiceServerUpdateDispatchData,
-	GatewayVoiceStateUpdateDispatchData,
-	Snowflake,
-} from 'discord-api-types/v8';
-import { EventEmitter } from 'events';
-
-interface DiscordGatewayAdapterEvents {
-	on(event: 'voiceStateUpdate', listener: (data: GatewayVoiceStateUpdateDispatchData) => void): this;
-	on(event: 'voiceServerUpdate', listener: (data: GatewayVoiceServerUpdateDispatchData) => void): this;
-}
-
-/**
- * Used to connect a VoiceConnection to a main Discord gateway connection.
- */
-export abstract class DiscordGatewayAdapter extends EventEmitter implements DiscordGatewayAdapterEvents {
-	/**
-	 * Called by @discordjs/voice when the adapter is no longer
-	 */
-	public abstract destroy?(): void;
-	/**
-	 * Called by @discordjs/voice when a payload needs to be forwarded to the gateway connection.
-	 * The creator of the adapter should make sure that they implement this logic.
-	 */
-	public abstract sendPayload(data: any): void;
-}
+import { Snowflake } from 'discord-api-types/v8';
+import { DiscordGatewayAdapterCreator } from './util/adapter';
 
 /**
  * The options that can be given when joining a voice channel
@@ -36,7 +12,7 @@ export interface CreateVoiceConnectionOptions {
 	 * related components. Defaults to false.
 	 */
 	debug?: boolean;
-	adapter: DiscordGatewayAdapter;
+	adapterCreator: DiscordGatewayAdapterCreator;
 }
 
 export interface JoinVoiceChannelOptions {
@@ -59,7 +35,7 @@ export function joinVoiceChannel(options: JoinVoiceChannelOptions & CreateVoiceC
 	};
 
 	return createVoiceConnection(joinConfig, {
-		adapter: options.adapter,
+		adapterCreator: options.adapterCreator,
 		debug: options.debug,
 	});
 }

--- a/src/joinVoiceChannel.ts
+++ b/src/joinVoiceChannel.ts
@@ -2,13 +2,22 @@ import { VoiceChannel } from 'discord.js';
 import { createVoiceConnection } from './VoiceConnection';
 import { JoinConfig } from './DataStore';
 import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v8';
+import { EventEmitter } from 'events';
 
 /**
  * Used to connect a VoiceConnection to a main Discord gateway connection.
  */
-export interface DiscordGatewayAdapter {
-	onVoiceServerUpdate(data: GatewayVoiceServerUpdateDispatchData): void;
-	onVoiceStateUpdate(data: GatewayVoiceStateUpdateDispatchData): void;
+export interface DiscordGatewayAdapter extends EventEmitter {
+	on(event: 'voiceServerUpdate', listener: (data: GatewayVoiceServerUpdateDispatchData) => void): this;
+	on(event: 'voiceStateUpdate', listener: (data: GatewayVoiceStateUpdateDispatchData) => void): this;
+	/**
+	 * Called by @discordjs/voice when the adapter is no longer
+	 */
+	destroy?(): void;
+	/**
+	 * Called by @discordjs/voice when a payload needs to be forwarded to the gateway connection.
+	 * The creator of the adapter should make sure that they implement this logic.
+	 */
 	sendPayload(data: any): void;
 }
 

--- a/src/joinVoiceChannel.ts
+++ b/src/joinVoiceChannel.ts
@@ -1,6 +1,16 @@
 import { VoiceChannel } from 'discord.js';
 import { createVoiceConnection } from './VoiceConnection';
 import { JoinConfig } from './DataStore';
+import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v8';
+
+/**
+ * Used to connect a VoiceConnection to a main Discord gateway connection.
+ */
+export interface DiscordGatewayAdapter {
+	onVoiceServerUpdate(data: GatewayVoiceServerUpdateDispatchData): void;
+	onVoiceStateUpdate(data: GatewayVoiceStateUpdateDispatchData): void;
+	sendPayload(data: any): void;
+}
 
 /**
  * The options that can be given when joining a voice channel
@@ -11,6 +21,7 @@ export interface JoinVoiceChannelOptions {
 	 * related components. Defaults to false.
 	 */
 	debug?: boolean;
+	adapter: DiscordGatewayAdapter;
 }
 
 /**
@@ -19,7 +30,7 @@ export interface JoinVoiceChannelOptions {
  * @param voiceChannel - the voice channel to connect to
  * @param options - the options for joining the voice channel
  */
-export function joinVoiceChannel(voiceChannel: VoiceChannel, options?: JoinVoiceChannelOptions) {
+export function joinVoiceChannel(voiceChannel: VoiceChannel, options: JoinVoiceChannelOptions) {
 	const joinConfig: JoinConfig = {
 		channelId: voiceChannel.id,
 		guild: voiceChannel.guild,

--- a/src/joinVoiceChannel.ts
+++ b/src/joinVoiceChannel.ts
@@ -4,21 +4,24 @@ import { JoinConfig } from './DataStore';
 import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v8';
 import { EventEmitter } from 'events';
 
+interface DiscordGatewayAdapterEvents {
+	on(event: 'voiceStateUpdate', listener: (data: GatewayVoiceStateUpdateDispatchData) => void): this;
+	on(event: 'voiceServerUpdate', listener: (data: GatewayVoiceServerUpdateDispatchData) => void): this;
+}
+
 /**
  * Used to connect a VoiceConnection to a main Discord gateway connection.
  */
-export interface DiscordGatewayAdapter extends EventEmitter {
-	on(event: 'voiceServerUpdate', listener: (data: GatewayVoiceServerUpdateDispatchData) => void): this;
-	on(event: 'voiceStateUpdate', listener: (data: GatewayVoiceStateUpdateDispatchData) => void): this;
+export abstract class DiscordGatewayAdapter extends EventEmitter implements DiscordGatewayAdapterEvents {
 	/**
 	 * Called by @discordjs/voice when the adapter is no longer
 	 */
-	destroy?(): void;
+	public abstract destroy?(): void;
 	/**
 	 * Called by @discordjs/voice when a payload needs to be forwarded to the gateway connection.
 	 * The creator of the adapter should make sure that they implement this logic.
 	 */
-	sendPayload(data: any): void;
+	public abstract sendPayload(data: any): void;
 }
 
 /**

--- a/src/joinVoiceChannel.ts
+++ b/src/joinVoiceChannel.ts
@@ -1,6 +1,5 @@
 import { createVoiceConnection } from './VoiceConnection';
 import { JoinConfig } from './DataStore';
-import { Snowflake } from 'discord-api-types/v8';
 import { DiscordGatewayAdapterCreator } from './util/adapter';
 
 /**
@@ -16,8 +15,8 @@ export interface CreateVoiceConnectionOptions {
 }
 
 export interface JoinVoiceChannelOptions {
-	channelId: Snowflake;
-	guildId: Snowflake;
+	channelId: string;
+	guildId: string;
 }
 
 /**

--- a/src/util/adapter.ts
+++ b/src/util/adapter.ts
@@ -1,4 +1,7 @@
-import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v8';
+import {
+	GatewayVoiceServerUpdateDispatchData,
+	GatewayVoiceStateUpdateDispatchData,
+} from 'discord-api-types/v8/gateway';
 
 /**
  * Methods that are provided by the @discordjs/voice library to implementations of
@@ -17,6 +20,12 @@ export interface DiscordGatewayAdapterImplementerMethods {
 	destroy?(): void;
 }
 
+/**
+ * A function used to build adapters. It accepts a methods parameter that contains functions that
+ * can be called by the implementer when new data is received on its gateway connection. In return,
+ * the implementer will return some methods that the library can call - e.g. to send messages on
+ * the gateway, or to signal that the adapter can be removed.
+ */
 export type DiscordGatewayAdapterCreator = (
 	methods: DiscordGatewayAdapterLibraryMethods,
 ) => DiscordGatewayAdapterImplementerMethods;

--- a/src/util/adapter.ts
+++ b/src/util/adapter.ts
@@ -1,0 +1,22 @@
+import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v8';
+
+/**
+ * Methods that are provided by the @discordjs/voice library to implementations of
+ * Discord gateway DiscordGatewayAdapters.
+ */
+export interface DiscordGatewayAdapterLibraryMethods {
+	onVoiceServerUpdate(data: GatewayVoiceServerUpdateDispatchData): void;
+	onVoiceStateUpdate(data: GatewayVoiceStateUpdateDispatchData): void;
+}
+
+/**
+ * Methods that are provided by the implementer of a Discord gateway DiscordGatewayAdapter.
+ */
+export interface DiscordGatewayAdapterImplementerMethods {
+	sendPayload(payload: any): void;
+	destroy?(): void;
+}
+
+export type DiscordGatewayAdapterCreator = (
+	methods: DiscordGatewayAdapterLibraryMethods,
+) => DiscordGatewayAdapterImplementerMethods;

--- a/src/util/generateDependencyReport.ts
+++ b/src/util/generateDependencyReport.ts
@@ -13,7 +13,6 @@ export default function generateDependencyReport() {
 	// general
 	report.push('Core Dependencies');
 	addVersion('@discordjs/voice');
-	addVersion('discord.js');
 	addVersion('prism-media');
 	report.push('');
 

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,2 +1,3 @@
 export * as generateDependencyReport from './generateDependencyReport';
 export * from './entersState';
+export * from './adapter';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #64 by implementing an adapter pattern. This removes `@discordjs/voice`'s dependency on Discord.js - it can now be used _anywhere_ (that supports JavaScript). All you need is a connection to the Discord gateway and some "glue" (discussed below).

For example, this enables running `@discordjs/voice`:

- With alternative Node.js Discord API libraries (e.g. [Cordis](https://github.com/cordis-lib) or [Eris](https://github.com/abalabahaha/eris))
- In a distributed architecture (making it scalable!)

## How the adapter works

When joining a voice channel, you must also specify an `adapter`:

```ts
await joinVoiceChannel({
  channelId,
  guildId,
  adapter
});
```

`adapter` is a function that allows the library and adapter implementer to share methods with each other:

```ts
const adapter = ({ onVoiceServerUpdate, onVoiceStateUpdate }) => {
  // Adapter lifecycle begins
  return {
    sendPayload(payload) {},
    destroy() {
      // Adapter lifecycle ends
    }
  }
});
```

An overview of the methods here:

- **`onVoiceServerUpdate`** - the _implementer_ must call this whenever a `VOICE_SERVER_UPDATE` packet is received that is relevant to the adapter (i.e. for the guild that the adapter was created for).
- **`onVoiceStateUpdate`** - the _implementer_ must call this whenever a `VOICE_STATE_UPDATE` packet is received that is relevant to the adapter.
- **`sendPayload`** - the _library_ will call this with a payload that it wants forwarding to the gateway connection of the adapter.
- **`destroy`** - the _library_ will call this when the adapter can no longer be used since its voice connection has been destroyed.

## Some pitfalls

- The implementer should **only** do setup logic (e.g. adding event listeners to a gateway, acknowledging that the adapter is valid by adding it to a list) once the `adapter` function is called (where the lifecycle begins). There is one case where the adapter function is _not_ called - when you are trying to establish a voice connection to a guild that already has one. To prevent memory leaks and needless event listeners, make sure that you **only** call your setup logic within the function itself.
- The `destroy` method is technically optional since it doesn't _need_ to exist for all use-cases. However, most use-cases will require it. For example, if you're tracking your adapters in a list somewhere, you could remove the adapter from the list when this method is called.

## Provided Discord.js adapter example

This PR includes an example for a Discord.js adapter. The plan is to have Discord.js provide this adapter itself. However, it does not currently do this, so as a stopgap, I've included one here as an example.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
