### PR TITLE
feat(AudioResource)!: use metadata instead of name

### DIFF
--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -63,7 +63,7 @@ type AudioPlayerState =
 	  }
 	| {
 			status: AudioPlayerStatus.Buffering;
-			resource: AudioResource;
+			resource: AudioResource<unknown>;
 			onReadableCallback: () => void;
 			onFailureCallback: () => void;
 			onStreamError: (error: Error) => void;
@@ -71,13 +71,13 @@ type AudioPlayerState =
 	| {
 			status: AudioPlayerStatus.Playing;
 			missedFrames: number;
-			resource: AudioResource;
+			resource: AudioResource<unknown>;
 			onStreamError: (error: Error) => void;
 	  }
 	| {
 			status: AudioPlayerStatus.Paused | AudioPlayerStatus.AutoPaused;
 			silencePacketsRemaining: number;
-			resource: AudioResource;
+			resource: AudioResource<unknown>;
 			onStreamError: (error: Error) => void;
 	  };
 
@@ -206,7 +206,7 @@ export class AudioPlayer extends EventEmitter {
 	 */
 	public set state(newState: AudioPlayerState) {
 		const oldState = this._state;
-		const newResource = Reflect.get(newState, 'resource') as AudioResource | undefined;
+		const newResource = Reflect.get(newState, 'resource') as AudioResource<unknown> | undefined;
 
 		if (oldState.status !== AudioPlayerStatus.Idle && oldState.resource !== newResource) {
 			oldState.resource.playStream.on('error', noop);
@@ -274,16 +274,16 @@ export class AudioPlayer extends EventEmitter {
 	 * @param resource - The resource to play
 	 * @throws Will throw if attempting to play an audio resource that has already ended, or is being played by another player.
 	 */
-	public play(resource: AudioResource) {
+	public play<T>(resource: AudioResource<T>) {
 		if (resource.playStream.readableEnded || resource.playStream.destroyed) {
-			throw new Error(`Cannot play a resource (${resource.name ?? 'unnamed'}) that has already ended.`);
+			throw new Error('Cannot play a resource that has already ended.');
 		}
 
 		if (resource.audioPlayer) {
 			if (resource.audioPlayer === this) {
 				return;
 			}
-			throw new Error(`Resource (${resource.name ?? 'unnamed'}) is already being played by another audio player.`);
+			throw new Error('Resource is already being played by another audio player.');
 		}
 		resource.audioPlayer = this;
 

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -63,7 +63,7 @@ type AudioPlayerState =
 	  }
 	| {
 			status: AudioPlayerStatus.Buffering;
-			resource: AudioResource<unknown>;
+			resource: AudioResource;
 			onReadableCallback: () => void;
 			onFailureCallback: () => void;
 			onStreamError: (error: Error) => void;
@@ -71,13 +71,13 @@ type AudioPlayerState =
 	| {
 			status: AudioPlayerStatus.Playing;
 			missedFrames: number;
-			resource: AudioResource<unknown>;
+			resource: AudioResource;
 			onStreamError: (error: Error) => void;
 	  }
 	| {
 			status: AudioPlayerStatus.Paused | AudioPlayerStatus.AutoPaused;
 			silencePacketsRemaining: number;
-			resource: AudioResource<unknown>;
+			resource: AudioResource;
 			onStreamError: (error: Error) => void;
 	  };
 
@@ -206,7 +206,7 @@ export class AudioPlayer extends EventEmitter {
 	 */
 	public set state(newState: AudioPlayerState) {
 		const oldState = this._state;
-		const newResource = Reflect.get(newState, 'resource') as AudioResource<unknown> | undefined;
+		const newResource = Reflect.get(newState, 'resource') as AudioResource | undefined;
 
 		if (oldState.status !== AudioPlayerStatus.Idle && oldState.resource !== newResource) {
 			oldState.resource.playStream.on('error', noop);

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import { addAudioPlayer, deleteAudioPlayer } from '../DataStore';
 import { noop } from '../util/util';
 import { VoiceConnection, VoiceConnectionStatus } from '../VoiceConnection';
+import { AudioPlayerError } from './AudioPlayerError';
 import { AudioResource } from './AudioResource';
 import { PlayerSubscription } from './PlayerSubscription';
 
@@ -295,9 +296,9 @@ export class AudioPlayer extends EventEmitter {
 				 * Emitted when there is an error emitted from the audio resource played by the audio player
 				 *
 				 * @event AudioPlayer#error
-				 * @type {Error}
+				 * @type {AudioPlayerError}
 				 */
-				this.emit('error', error);
+				this.emit('error', new AudioPlayerError(error, this.state.resource));
 			}
 
 			if (this.state.status !== AudioPlayerStatus.Idle && this.state.resource === resource) {

--- a/src/audio/AudioPlayerError.ts
+++ b/src/audio/AudioPlayerError.ts
@@ -1,0 +1,15 @@
+import type { AudioResource } from './AudioResource';
+
+/**
+ * An error emitted by an AudioPlayer. Contains an attached resource to aid with
+ * debugging and identifying where the error came from.
+ */
+export class AudioPlayerError extends Error {
+	private readonly resource: AudioResource;
+	public constructor(error: Error, resource: AudioResource) {
+		super(error.message);
+		this.resource = resource;
+		this.name = error.name;
+		this.stack = error.stack;
+	}
+}

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -16,7 +16,7 @@ interface CreateAudioResourceOptions<T> {
 	/**
 	 * Optional metadata that can be attached to the resource (e.g. track title, random ID).
 	 * This is useful for identification purposes when the resource is passed around in events.
-	 * @see AudioResource#metadata
+	 * See {@link AudioResource.metadata}
 	 */
 	metadata?: T;
 

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -29,7 +29,7 @@ interface CreateAudioResourceOptions<T> {
 /**
  * Represents an audio resource that can be played by an audio player.
  */
-export class AudioResource<T> {
+export class AudioResource<T = unknown> {
 	/**
 	 * An object-mode Readable stream that emits Opus packets. This is what is played by audio players.
 	 */

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -16,6 +16,7 @@ interface CreateAudioResourceOptions<T> {
 	/**
 	 * Optional metadata that can be attached to the resource (e.g. track title, random ID).
 	 * This is useful for identification purposes when the resource is passed around in events.
+	 * @see AudioResource#metadata
 	 */
 	metadata?: T;
 

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -7,17 +7,17 @@ import type { AudioPlayer } from './AudioPlayer';
 /**
  * Options that are set when creating a new audio resource.
  */
-interface CreateAudioResourceOptions {
+interface CreateAudioResourceOptions<T> {
 	/**
 	 * The type of the input stream. Defaults to `StreamType.Arbitrary`.
 	 */
 	inputType?: StreamType;
 
 	/**
-	 * An optional name that can be attached to the resource. This could be a track title, song name etc.
+	 * Optional metadata that can be attached to the resource (e.g. track title, random ID).
 	 * This is useful for identification purposes when the resource is passed around in events.
 	 */
-	name?: string;
+	metadata?: T;
 
 	/**
 	 * Whether or not inline volume should be enabled. If enabled, you will be able to change the volume
@@ -29,7 +29,7 @@ interface CreateAudioResourceOptions {
 /**
  * Represents an audio resource that can be played by an audio player.
  */
-export class AudioResource {
+export class AudioResource<T> {
 	/**
 	 * An object-mode Readable stream that emits Opus packets. This is what is played by audio players.
 	 */
@@ -43,9 +43,9 @@ export class AudioResource {
 	public readonly pipeline: Edge[];
 
 	/**
-	 * An optional name that can be used to identify the resource.
+	 * Optional metadata that can be used to identify the resource.
 	 */
-	public name?: string;
+	public metadata?: T;
 
 	/**
 	 * If the resource was created with inline volume transformation enabled, then this will be a
@@ -58,10 +58,10 @@ export class AudioResource {
 	 */
 	public audioPlayer?: AudioPlayer;
 
-	public constructor(pipeline: Edge[], playStream: Readable, name?: string, volume?: VolumeTransformer) {
+	public constructor(pipeline: Edge[], playStream: Readable, metadata?: T, volume?: VolumeTransformer) {
 		this.pipeline = pipeline;
 		this.playStream = playStream;
-		this.name = name;
+		this.metadata = metadata;
 		this.volume = volume;
 	}
 }
@@ -86,7 +86,10 @@ const VOLUME_CONSTRAINT = (path: Edge[]) => path.some((edge) => edge.type === Tr
  * @param input - The resource to play.
  * @param options - Configurable options for creating the resource.
  */
-export function createAudioResource(input: string | Readable, options: CreateAudioResourceOptions = {}): AudioResource {
+export function createAudioResource<T>(
+	input: string | Readable,
+	options: CreateAudioResourceOptions<T> = {},
+): AudioResource<T> {
 	let inputType = options.inputType ?? StreamType.Arbitrary;
 
 	// string inputs can only be used with FFmpeg
@@ -116,7 +119,7 @@ export function createAudioResource(input: string | Readable, options: CreateAud
 	return {
 		playStream: (playStream as any) as Readable,
 		pipeline: transformerPipeline,
-		name: options.name,
+		metadata: options.metadata,
 		volume,
 	};
 }

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -102,10 +102,7 @@ export function createAudioResource<T>(
 	if (transformerPipeline.length === 0) {
 		if (typeof input === 'string') throw new Error(`Invalid pipeline constructed for string resource '${input}'`);
 		// No adjustments required
-		return {
-			playStream: input,
-			pipeline: [],
-		};
+		return new AudioResource([], input, options.metadata);
 	}
 	const streams = transformerPipeline.map((pipe) => pipe.transformer(input));
 	if (typeof input !== 'string') streams.unshift(input);
@@ -116,10 +113,5 @@ export function createAudioResource<T>(
 	// attempt to find the volume transformer in the pipeline (if one exists)
 	const volume = streams.find((stream) => stream instanceof VolumeTransformer) as VolumeTransformer | undefined;
 
-	return {
-		playStream: (playStream as any) as Readable,
-		pipeline: transformerPipeline,
-		metadata: options.metadata,
-		volume,
-	};
+	return new AudioResource(transformerPipeline, (playStream as any) as Readable, options.metadata, volume);
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #68

Example usage:

```ts
interface TrackMetadata {
  title: string;
  artist: string;
}

const resource = createAudioResource<TrackMetadata>('/my/path/file.mp3', {
  metadata: {
    title: 'make discord.js voice great again speech',
    artist: 'hydrabolt'
  }
});
```


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

