### PR TITLE
refactor(AudioResource): default T to unknown

### DIFF
--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -63,7 +63,7 @@ type AudioPlayerState =
 	  }
 	| {
 			status: AudioPlayerStatus.Buffering;
-			resource: AudioResource<unknown>;
+			resource: AudioResource;
 			onReadableCallback: () => void;
 			onFailureCallback: () => void;
 			onStreamError: (error: Error) => void;
@@ -71,13 +71,13 @@ type AudioPlayerState =
 	| {
 			status: AudioPlayerStatus.Playing;
 			missedFrames: number;
-			resource: AudioResource<unknown>;
+			resource: AudioResource;
 			onStreamError: (error: Error) => void;
 	  }
 	| {
 			status: AudioPlayerStatus.Paused | AudioPlayerStatus.AutoPaused;
 			silencePacketsRemaining: number;
-			resource: AudioResource<unknown>;
+			resource: AudioResource;
 			onStreamError: (error: Error) => void;
 	  };
 
@@ -206,7 +206,7 @@ export class AudioPlayer extends EventEmitter {
 	 */
 	public set state(newState: AudioPlayerState) {
 		const oldState = this._state;
-		const newResource = Reflect.get(newState, 'resource') as AudioResource<unknown> | undefined;
+		const newResource = Reflect.get(newState, 'resource') as AudioResource | undefined;
 
 		if (oldState.status !== AudioPlayerStatus.Idle && oldState.resource !== newResource) {
 			oldState.resource.playStream.on('error', noop);

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -29,7 +29,7 @@ interface CreateAudioResourceOptions<T> {
 /**
  * Represents an audio resource that can be played by an audio player.
  */
-export class AudioResource<T> {
+export class AudioResource<T = unknown> {
 	/**
 	 * An object-mode Readable stream that emits Opus packets. This is what is played by audio players.
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR defaults the metadata type (T) to unknown as suggested by https://github.com/discordjs/voice/pull/69#pullrequestreview-600160882 (#69)

**Status and versioning classification:**
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
