### PR TITLE
refactor: split states into a union of interfaces

### DIFF
--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -37,29 +37,72 @@ export enum VoiceConnectionStatus {
 }
 
 /**
+ * The state that a VoiceConnection will be in when it is waiting to receive a VOICE_SERVER_UPDATE and
+ * VOICE_STATE_UPDATE packet from Discord, provided by the adapter.
+ */
+export interface VoiceConnectionSignallingState {
+	status: VoiceConnectionStatus.Signalling;
+	subscription?: PlayerSubscription;
+	adapter: DiscordGatewayAdapterImplementerMethods;
+}
+
+/**
+ * The state that a VoiceConnection will be in when it is not connected to a Discord voice server, and
+ * is not making an attempt to do so.
+ *
+ * It is possible to attempt a reconnect when in this state, but it will not be automatically done by
+ * the library.
+ */
+export interface VoiceConnectionDisconnectedState {
+	status: VoiceConnectionStatus.Disconnected;
+	/**
+	 * The close code of the WebSocket connection to the Discord voice server.
+	 */
+	closeCode: number;
+	subscription?: PlayerSubscription;
+	adapter: DiscordGatewayAdapterImplementerMethods;
+}
+
+/**
+ * The state that a VoiceConnection will be in when it is establishing a connection to a Discord
+ * voice server.
+ */
+export interface VoiceConnectionConnectingState {
+	status: VoiceConnectionStatus.Connecting;
+	networking: Networking;
+	subscription?: PlayerSubscription;
+	adapter: DiscordGatewayAdapterImplementerMethods;
+}
+
+/**
+ * The state that a VoiceConnection will be in when it has an active connection to a Discord
+ * voice server.
+ */
+export interface VoiceConnectionReadyState {
+	status: VoiceConnectionStatus.Ready;
+	networking: Networking;
+	subscription?: PlayerSubscription;
+	adapter: DiscordGatewayAdapterImplementerMethods;
+}
+
+/**
+ * The state that a VoiceConnection will be in when it has been permanently been destroyed by the
+ * user and untracked by the library. It cannot be reconnected, instead, a new VoiceConnection
+ * needs to be established.
+ */
+export interface VoiceConnectionDestroyedState {
+	status: VoiceConnectionStatus.Destroyed;
+}
+
+/**
  * The various states that a voice connection can be in.
  */
 export type VoiceConnectionState =
-	| {
-			status: VoiceConnectionStatus.Signalling;
-			subscription?: PlayerSubscription;
-			adapter: DiscordGatewayAdapterImplementerMethods;
-	  }
-	| {
-			status: VoiceConnectionStatus.Disconnected;
-			closeCode: number;
-			subscription?: PlayerSubscription;
-			adapter: DiscordGatewayAdapterImplementerMethods;
-	  }
-	| {
-			status: VoiceConnectionStatus.Connecting | VoiceConnectionStatus.Ready;
-			networking: Networking;
-			subscription?: PlayerSubscription;
-			adapter: DiscordGatewayAdapterImplementerMethods;
-	  }
-	| {
-			status: VoiceConnectionStatus.Destroyed;
-	  };
+	| VoiceConnectionSignallingState
+	| VoiceConnectionDisconnectedState
+	| VoiceConnectionConnectingState
+	| VoiceConnectionReadyState
+	| VoiceConnectionDestroyedState;
 
 /**
  * A connection to the voice server of a Guild, can be used to play audio in voice channels.

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -47,7 +47,7 @@ export enum AudioPlayerStatus {
 /**
  * Options that can be passed when creating an audio player, used to specify its behavior.
  */
-interface CreateAudioPlayerOptions {
+export interface CreateAudioPlayerOptions {
 	debug?: boolean;
 	behaviors?: {
 		noSubscriber?: NoSubscriberBehavior;
@@ -58,7 +58,7 @@ interface CreateAudioPlayerOptions {
 /**
  * The state that an AudioPlayer is in when it has no resource to play. This is the starting state.
  */
-interface AudioPlayerIdleState {
+export interface AudioPlayerIdleState {
 	status: AudioPlayerStatus.Idle;
 }
 
@@ -67,7 +67,7 @@ interface AudioPlayerIdleState {
  * happens, the AudioPlayer will enter the Playing state. If the resource ends/errors before this, then
  * it will re-enter the Idle state.
  */
-interface AudioPlayerBufferingState {
+export interface AudioPlayerBufferingState {
 	status: AudioPlayerStatus.Buffering;
 	/**
 	 * The resource that the AudioPlayer is waiting for
@@ -82,7 +82,7 @@ interface AudioPlayerBufferingState {
  * The state that an AudioPlayer is in when it is actively playing an AudioResource. When playback ends,
  * it will enter the Idle state.
  */
-interface AudioPlayerPlayingState {
+export interface AudioPlayerPlayingState {
 	status: AudioPlayerStatus.Playing;
 	/**
 	 * The number of consecutive times that the audio resource has been unable to provide an Opus frame.
@@ -104,7 +104,7 @@ interface AudioPlayerPlayingState {
  * The state that an AudioPlayer is in when it has either been explicitly paused by the user, or done
  * automatically by the AudioPlayer itself if there are no available subscribers.
  */
-interface AudioPlayerPausedState {
+export interface AudioPlayerPausedState {
 	status: AudioPlayerStatus.Paused | AudioPlayerStatus.AutoPaused;
 	/**
 	 * How many silence packets still need to be played to avoid audio interpolation due to the stream suddenly pausing

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -510,8 +510,7 @@ export class AudioPlayer extends EventEmitter {
 		if (state.status === AudioPlayerStatus.Paused || state.status === AudioPlayerStatus.AutoPaused) {
 			if (state.silencePacketsRemaining > 0) {
 				state.silencePacketsRemaining--;
-				state.playbackDuration += 20;
-				this._preparePacket(SILENCE_FRAME, playable);
+				this._preparePacket(SILENCE_FRAME, playable, state);
 				if (state.silencePacketsRemaining === 0) {
 					this._signalStopSpeaking();
 				}
@@ -540,12 +539,11 @@ export class AudioPlayer extends EventEmitter {
 
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 		if (state.status === AudioPlayerStatus.Playing) {
-			state.playbackDuration += 20;
 			if (packet) {
-				this._preparePacket(packet, playable);
+				this._preparePacket(packet, playable, state);
 				state.missedFrames = 0;
 			} else {
-				this._preparePacket(SILENCE_FRAME, playable);
+				this._preparePacket(SILENCE_FRAME, playable, state);
 				state.missedFrames++;
 				if (state.missedFrames >= this.behaviors.maxMissedFrames) {
 					this.stop();
@@ -569,7 +567,12 @@ export class AudioPlayer extends EventEmitter {
 	 * @param packet - The Opus packet to be prepared by each receiver
 	 * @param receivers - The connections that should play this packet
 	 */
-	private _preparePacket(packet: Buffer, receivers: VoiceConnection[]) {
+	private _preparePacket(
+		packet: Buffer,
+		receivers: VoiceConnection[],
+		state: AudioPlayerPlayingState | AudioPlayerPausedState,
+	) {
+		state.playbackDuration += 20;
 		receivers.forEach((connection) => connection.prepareAudioPacket(packet));
 	}
 }

--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -1,4 +1,14 @@
-export { AudioPlayer, AudioPlayerStatus, NoSubscriberBehavior, createAudioPlayer } from './AudioPlayer';
+export {
+	AudioPlayer,
+	AudioPlayerStatus,
+	NoSubscriberBehavior,
+	createAudioPlayer,
+	AudioPlayerBufferingState,
+	AudioPlayerIdleState,
+	AudioPlayerPausedState,
+	AudioPlayerPlayingState,
+	CreateAudioPlayerOptions,
+} from './AudioPlayer';
 
 export { AudioResource, createAudioResource } from './AudioResource';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,15 @@ export * from './joinVoiceChannel';
 export * from './audio';
 export * from './util';
 
-export { VoiceConnection, VoiceConnectionState, VoiceConnectionStatus } from './VoiceConnection';
+export {
+	VoiceConnection,
+	VoiceConnectionState,
+	VoiceConnectionStatus,
+	VoiceConnectionConnectingState,
+	VoiceConnectionDestroyedState,
+	VoiceConnectionDisconnectedState,
+	VoiceConnectionReadyState,
+	VoiceConnectionSignallingState,
+} from './VoiceConnection';
 
 export { getVoiceConnection } from './DataStore';

--- a/src/networking/Networking.ts
+++ b/src/networking/Networking.ts
@@ -28,32 +28,92 @@ export enum NetworkingStatusCode {
 }
 
 /**
+ * The initial Networking state. Instances will be in this state when a WebSocket connection to a Discord
+ * voice gateway is being opened.
+ */
+export interface NetworkingOpeningWsState {
+	code: NetworkingStatusCode.OpeningWs;
+	ws: VoiceWebSocket;
+	connectionOptions: ConnectionOptions;
+}
+
+/**
+ * The state that a Networking instance will be in when it is attempting to authorize itself.
+ */
+export interface NetworkingIdentifyingState {
+	code: NetworkingStatusCode.Identifying;
+	ws: VoiceWebSocket;
+	connectionOptions: ConnectionOptions;
+}
+
+/**
+ * The state that a Networking instance will be in when opening a UDP connection to the IP and port provided
+ * by Discord, as well as performing IP discovery.
+ */
+export interface NetworkingUdpHandshakingState {
+	code: NetworkingStatusCode.UdpHandshaking;
+	ws: VoiceWebSocket;
+	udp: VoiceUDPSocket;
+	connectionOptions: ConnectionOptions;
+	connectionData: Pick<ConnectionData, 'ssrc'>;
+}
+
+/**
+ * The state that a Networking instance will be in when selecting an encryption protocol for audio packets.
+ */
+export interface NetworkingSelectingProtocolState {
+	code: NetworkingStatusCode.SelectingProtocol;
+	ws: VoiceWebSocket;
+	udp: VoiceUDPSocket;
+	connectionOptions: ConnectionOptions;
+	connectionData: Pick<ConnectionData, 'ssrc'>;
+}
+
+/**
+ * The state that a Networking instance will be in when it has a fully established connection to a Discord
+ * voice server.
+ */
+export interface NetworkingReadyState {
+	code: NetworkingStatusCode.Ready;
+	ws: VoiceWebSocket;
+	udp: VoiceUDPSocket;
+	connectionOptions: ConnectionOptions;
+	connectionData: ConnectionData;
+	preparedPacket?: Buffer;
+}
+
+/**
+ * The state that a Networking instance will be in when its connection has been dropped unexpectedly, and it
+ * is attempting to resume an existing session.
+ */
+export interface NetworkingResumingState {
+	code: NetworkingStatusCode.Resuming;
+	ws: VoiceWebSocket;
+	udp: VoiceUDPSocket;
+	connectionOptions: ConnectionOptions;
+	connectionData: ConnectionData;
+	preparedPacket?: Buffer;
+}
+
+/**
+ * The state that a Networking instance will be in when it has been destroyed. It cannot be recovered from this
+ * state.
+ */
+export interface NetworkingClosedState {
+	code: NetworkingStatusCode.Closed;
+}
+
+/**
  * The various states that a networking instance can be in.
  */
 export type NetworkingState =
-	| {
-			code: NetworkingStatusCode.OpeningWs | NetworkingStatusCode.Identifying;
-			ws: VoiceWebSocket;
-			connectionOptions: ConnectionOptions;
-	  }
-	| {
-			code: NetworkingStatusCode.UdpHandshaking | NetworkingStatusCode.SelectingProtocol;
-			ws: VoiceWebSocket;
-			udp: VoiceUDPSocket;
-			connectionOptions: ConnectionOptions;
-			connectionData: Pick<ConnectionData, 'ssrc'>;
-	  }
-	| {
-			code: NetworkingStatusCode.Ready | NetworkingStatusCode.Resuming;
-			ws: VoiceWebSocket;
-			udp: VoiceUDPSocket;
-			connectionOptions: ConnectionOptions;
-			connectionData: ConnectionData;
-			preparedPacket?: Buffer;
-	  }
-	| {
-			code: NetworkingStatusCode.Closed;
-	  };
+	| NetworkingOpeningWsState
+	| NetworkingIdentifyingState
+	| NetworkingUdpHandshakingState
+	| NetworkingSelectingProtocolState
+	| NetworkingReadyState
+	| NetworkingResumingState
+	| NetworkingClosedState;
 
 /**
  * Details required to connect to the Discord voice gateway. These details


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Improves documentation for the various states of `AudioPlayer`, `VoiceConnection`, and `Networking`.

An refactor was made to `AudioPlayer`, where a state of a playable type is passed to the `_preparePacket` method. This allows it to increment the `playbackDuration` itself without having to perform a status assertion.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (additional interfaces exported)
