### PR TITLE
feat: allow adapter creator to call a destroy method

### DIFF
--- a/examples/basic/adapter.ts
+++ b/examples/basic/adapter.ts
@@ -28,14 +28,12 @@ function trackClient(client: Client) {
 const trackedGuilds = new Map<WebSocketShard, Set<Snowflake>>();
 
 function cleanupGuilds(shard: WebSocketShard) {
-	shard.once('close', () => {
-		const guilds = trackedGuilds.get(shard);
-		if (guilds?.values) {
-			for (const guildID of guilds.values()) {
-				adapters.get(guildID)?.destroy();
-			}
+	const guilds = trackedGuilds.get(shard);
+	if (guilds) {
+		for (const guildID of guilds.values()) {
+			adapters.get(guildID)?.destroy();
 		}
-	});
+	}
 }
 
 function trackGuild(guild: Guild) {

--- a/examples/basic/adapter.ts
+++ b/examples/basic/adapter.ts
@@ -39,13 +39,15 @@ function cleanupGuilds(shard: WebSocketShard) {
 }
 
 function trackGuild(guild: Guild) {
-	if (!trackedGuilds.has(guild.shard)) {
+	let guilds = trackedGuilds.get(guild.shard);
+	if (!guilds) {
 		const cleanup = () => cleanupGuilds(guild.shard);
 		guild.shard.on('close', cleanup);
 		guild.shard.on('destroyed', cleanup);
-		trackedGuilds.set(guild.shard, new Set());
+		guilds = new Set();
+		trackedGuilds.set(guild.shard, guilds);
 	}
-	trackedGuilds.get(guild.shard)!.add(guild.id);
+	guilds.add(guild.id);
 }
 
 /**

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -461,4 +461,11 @@ describe('Adapter', () => {
 		adapter.libMethods.onVoiceStateUpdate(dummy);
 		expect(voiceConnection['addStatePacket']).toHaveBeenCalledWith(dummy);
 	});
+
+	test('destroy', () => {
+		const { adapter, voiceConnection } = createFakeVoiceConnection();
+		adapter.libMethods.destroy();
+		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Destroyed);
+		expect(adapter.sendPayload).not.toHaveBeenCalled();
+	});
 });

--- a/src/util/adapter.ts
+++ b/src/util/adapter.ts
@@ -10,6 +10,7 @@ import {
 export interface DiscordGatewayAdapterLibraryMethods {
 	onVoiceServerUpdate(data: GatewayVoiceServerUpdateDispatchData): void;
 	onVoiceStateUpdate(data: GatewayVoiceStateUpdateDispatchData): void;
+	destroy(): void;
 }
 
 /**
@@ -17,7 +18,7 @@ export interface DiscordGatewayAdapterLibraryMethods {
  */
 export interface DiscordGatewayAdapterImplementerMethods {
 	sendPayload(payload: any): void;
-	destroy?(): void;
+	destroy(): void;
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #78.

When the provider of an adapter realises that the adapter it has provided is no longer valid (e.g. the shard of the guild it is for has disconnected), it can now call a `destroy()` method so that its VoiceConnection can self-destruct.

The example for a Discord.js adapter has been updated to reflect this.

Additionally, the existing `destroy()` function is now required (as opposed to optional), as not handling destroy calls is just bad behaviour.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
