### PR TITLE
test(VoiceConnection): add unit tests

### DIFF
--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -313,6 +313,7 @@ export class VoiceConnection extends EventEmitter {
 				...this.state,
 				status: VoiceConnectionStatus.Signalling,
 			};
+			this.reconnectAttempts++;
 			this.state.adapter.sendPayload(createJoinVoiceChannelPayload(this.joinConfig));
 		}
 	}

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -156,8 +156,8 @@ export class VoiceConnection extends EventEmitter {
 		this.onNetworkingDebug = this.onNetworkingDebug.bind(this);
 
 		const adapter = adapterCreator({
-			onVoiceServerUpdate: this.addServerPacket.bind(this),
-			onVoiceStateUpdate: this.addStatePacket.bind(this),
+			onVoiceServerUpdate: (data) => this.addServerPacket(data),
+			onVoiceStateUpdate: (data) => this.addStatePacket(data),
 		});
 
 		this._state = { status: VoiceConnectionStatus.Signalling, adapter };

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -241,5 +241,6 @@ describe('VoiceConnection#onNetworkingClose', () => {
 		voiceConnection['onNetworkingClose'](1234);
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Signalling);
 		expect(adapter.sendPayload).toHaveBeenCalledWith(fakePayload);
+		expect(voiceConnection.reconnectAttempts).toBe(1);
 	});
 });

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -2,6 +2,7 @@
 import { createVoiceConnection, VoiceConnection, VoiceConnectionStatus } from '../VoiceConnection';
 import * as _DataStore from '../DataStore';
 jest.mock('../DataStore');
+jest.mock('../networking/Networking');
 
 const DataStore = (_DataStore as unknown) as jest.Mocked<typeof _DataStore>;
 
@@ -25,6 +26,16 @@ function createJoinConfig() {
 		selfDeaf: true,
 		selfMute: false,
 	};
+}
+
+function createFakeVoiceConnection() {
+	const adapter = createFakeAdapter();
+	const joinConfig = createJoinConfig();
+	const voiceConnection = new VoiceConnection(joinConfig, {
+		debug: false,
+		adapterCreator: adapter.creator,
+	});
+	return { adapter, joinConfig, voiceConnection };
 }
 
 beforeEach(() => {
@@ -87,12 +98,7 @@ describe('createVoiceConnection', () => {
 
 describe('VoiceConnection#addServerPacket', () => {
 	test('Stores the packet and attempts to configure networking', () => {
-		const adapter = createFakeAdapter();
-		const joinConfig = createJoinConfig();
-		const voiceConnection = new VoiceConnection(joinConfig, {
-			debug: false,
-			adapterCreator: adapter.creator,
-		});
+		const { voiceConnection } = createFakeVoiceConnection();
 		voiceConnection.configureNetworking = jest.fn();
 		const fake = Symbol('fake') as any;
 		voiceConnection['addServerPacket'](fake);
@@ -101,12 +107,7 @@ describe('VoiceConnection#addServerPacket', () => {
 	});
 
 	test('Overwrites existing packet', () => {
-		const adapter = createFakeAdapter();
-		const joinConfig = createJoinConfig();
-		const voiceConnection = new VoiceConnection(joinConfig, {
-			debug: false,
-			adapterCreator: adapter.creator,
-		});
+		const { voiceConnection } = createFakeVoiceConnection();
 		voiceConnection['packets'].server = Symbol('old') as any;
 		voiceConnection.configureNetworking = jest.fn();
 		const fake = Symbol('fake') as any;
@@ -118,13 +119,7 @@ describe('VoiceConnection#addServerPacket', () => {
 
 describe('VoiceConnection#addStatePacket', () => {
 	test('State is assigned to joinConfig', () => {
-		const adapter = createFakeAdapter();
-		const joinConfig = createJoinConfig();
-		const voiceConnection = new VoiceConnection(joinConfig, {
-			debug: false,
-			adapterCreator: adapter.creator,
-		});
-
+		const { voiceConnection } = createFakeVoiceConnection();
 		voiceConnection['addStatePacket']({
 			self_deaf: true,
 			self_mute: true,

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -114,9 +114,9 @@ describe('VoiceConnection#addServerPacket', () => {
 	test('Stores the packet and attempts to configure networking', () => {
 		const { voiceConnection } = createFakeVoiceConnection();
 		voiceConnection.configureNetworking = jest.fn();
-		const fake = Symbol('fake') as any;
-		voiceConnection['addServerPacket'](fake);
-		expect(voiceConnection['packets'].server).toBe(fake);
+		const dummy = Symbol('dummy') as any;
+		voiceConnection['addServerPacket'](dummy);
+		expect(voiceConnection['packets'].server).toBe(dummy);
 		expect(voiceConnection.configureNetworking).toHaveBeenCalled();
 	});
 
@@ -124,9 +124,9 @@ describe('VoiceConnection#addServerPacket', () => {
 		const { voiceConnection } = createFakeVoiceConnection();
 		voiceConnection['packets'].server = Symbol('old') as any;
 		voiceConnection.configureNetworking = jest.fn();
-		const fake = Symbol('fake') as any;
-		voiceConnection['addServerPacket'](fake);
-		expect(voiceConnection['packets'].server).toBe(fake);
+		const dummy = Symbol('dummy') as any;
+		voiceConnection['addServerPacket'](dummy);
+		expect(voiceConnection['packets'].server).toBe(dummy);
 		expect(voiceConnection.configureNetworking).toHaveBeenCalled();
 	});
 });
@@ -239,14 +239,14 @@ describe('VoiceConnection#onNetworkingClose', () => {
 	});
 
 	test('Attempts reconnect for codes != 4014', () => {
-		const fakePayload = Symbol('fake') as any;
+		const dummyPayload = Symbol('dummy') as any;
 		const { voiceConnection, adapter, joinConfig } = createFakeVoiceConnection();
 		DataStore.createJoinVoiceChannelPayload.mockImplementation((config) =>
-			config === joinConfig ? fakePayload : undefined,
+			config === joinConfig ? dummyPayload : undefined,
 		);
 		voiceConnection['onNetworkingClose'](1234);
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Signalling);
-		expect(adapter.sendPayload).toHaveBeenCalledWith(fakePayload);
+		expect(adapter.sendPayload).toHaveBeenCalledWith(dummyPayload);
 		expect(voiceConnection.reconnectAttempts).toBe(1);
 	});
 });
@@ -331,8 +331,8 @@ describe('VoiceConnection#destroy', () => {
 		DataStore.getVoiceConnection.mockImplementation((guildId) =>
 			joinConfig.guildId === guildId ? voiceConnection : undefined,
 		);
-		const fake = Symbol('fake');
-		DataStore.createJoinVoiceChannelPayload.mockImplementation(() => fake as any);
+		const dummy = Symbol('dummy');
+		DataStore.createJoinVoiceChannelPayload.mockImplementation(() => dummy as any);
 		voiceConnection.destroy();
 		expect(DataStore.getVoiceConnection).toHaveReturnedWith(voiceConnection);
 		expect(DataStore.untrackVoiceConnection).toHaveBeenCalledWith(joinConfig.guildId);
@@ -340,7 +340,7 @@ describe('VoiceConnection#destroy', () => {
 			channelId: null,
 			guildId: joinConfig.guildId,
 		});
-		expect(adapter.sendPayload).toHaveBeenCalledWith(fake);
+		expect(adapter.sendPayload).toHaveBeenCalledWith(dummy);
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Destroyed);
 	});
 });
@@ -356,8 +356,8 @@ describe('VoiceConnection#reconnect', () => {
 	});
 
 	test('Reconnects in a disconnected state', () => {
-		const fake = Symbol('fake') as any;
-		DataStore.createJoinVoiceChannelPayload.mockImplementation(() => fake);
+		const dummy = Symbol('dummy') as any;
+		DataStore.createJoinVoiceChannelPayload.mockImplementation(() => dummy);
 
 		const { voiceConnection, adapter } = createFakeVoiceConnection();
 		voiceConnection.state = {
@@ -367,7 +367,7 @@ describe('VoiceConnection#reconnect', () => {
 		};
 		expect(voiceConnection.reconnect()).toBe(true);
 		expect(voiceConnection.reconnectAttempts).toBe(1);
-		expect(adapter.sendPayload).toHaveBeenCalledWith(fake);
+		expect(adapter.sendPayload).toHaveBeenCalledWith(dummy);
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Signalling);
 	});
 });
@@ -387,9 +387,9 @@ describe('VoiceConnection#subscribe', () => {
 		const { voiceConnection } = createFakeVoiceConnection();
 		const adapter = (voiceConnection.state as VoiceConnectionSignallingState).adapter;
 		const player = new AudioPlayer.AudioPlayer();
-		const fake = Symbol('fake');
-		player['subscribe'] = jest.fn().mockImplementation(() => fake);
-		expect(voiceConnection.subscribe(player)).toBe(fake);
+		const dummy = Symbol('dummy');
+		player['subscribe'] = jest.fn().mockImplementation(() => dummy);
+		expect(voiceConnection.subscribe(player)).toBe(dummy);
 		expect(player['subscribe']).toHaveBeenCalledWith(voiceConnection);
 		expect(voiceConnection.state).toMatchObject({
 			status: VoiceConnectionStatus.Signalling,

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -1,0 +1,85 @@
+import { createVoiceConnection, VoiceConnection, VoiceConnectionStatus } from '../VoiceConnection';
+import * as _DataStore from '../DataStore';
+jest.mock('../DataStore');
+
+const DataStore = (_DataStore as unknown) as jest.Mocked<typeof _DataStore>;
+
+function createFakeAdapter() {
+	const sendPayload = jest.fn();
+	const destroy = jest.fn();
+	return {
+		sendPayload,
+		destroy,
+		creator: jest.fn(() => ({
+			sendPayload,
+			destroy,
+		})),
+	};
+}
+
+function createJoinConfig() {
+	return {
+		channelId: '1',
+		guildId: '2',
+		selfDeaf: true,
+		selfMute: false,
+	};
+}
+
+beforeEach(() => {
+	DataStore.createJoinVoiceChannelPayload.mockReset();
+	DataStore.getVoiceConnection.mockReset();
+	DataStore.trackVoiceConnection.mockReset();
+	DataStore.untrackVoiceConnection.mockReset();
+});
+
+describe('createVoiceConnection', () => {
+	test('New voice connection', () => {
+		const mockPayload = Symbol('mock') as any;
+		DataStore.createJoinVoiceChannelPayload.mockImplementation(() => mockPayload);
+		const adapter = createFakeAdapter();
+		const joinConfig = createJoinConfig();
+		const voiceConnection = createVoiceConnection(joinConfig, {
+			debug: false,
+			adapterCreator: adapter.creator,
+		});
+		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Signalling);
+		expect(DataStore.getVoiceConnection).toHaveBeenCalledTimes(1);
+		expect(DataStore.trackVoiceConnection).toHaveBeenCalledWith(joinConfig.guildId, voiceConnection);
+		expect(DataStore.untrackVoiceConnection).not.toHaveBeenCalled();
+		expect(adapter.sendPayload).toHaveBeenCalledWith(mockPayload);
+	});
+
+	test('Reconfiguring existing connection', () => {
+		const mockPayload = Symbol('mock') as any;
+
+		DataStore.createJoinVoiceChannelPayload.mockImplementation(() => mockPayload);
+
+		const existingAdapter = createFakeAdapter();
+		const existingJoinConfig = createJoinConfig();
+		const existingVoiceConnection = new VoiceConnection(existingJoinConfig, {
+			debug: false,
+			adapterCreator: existingAdapter.creator,
+		});
+
+		const stateSetter = jest.spyOn(existingVoiceConnection, 'state', 'set');
+
+		DataStore.getVoiceConnection.mockImplementation((guildId) =>
+			guildId === existingJoinConfig.guildId ? existingVoiceConnection : null,
+		);
+
+		const newAdapter = createFakeAdapter();
+		const newJoinConfig = createJoinConfig();
+		const newVoiceConnection = createVoiceConnection(newJoinConfig, {
+			debug: false,
+			adapterCreator: newAdapter.creator,
+		});
+		expect(DataStore.getVoiceConnection).toHaveBeenCalledWith(newJoinConfig.guildId);
+		expect(DataStore.trackVoiceConnection).not.toHaveBeenCalled();
+		expect(DataStore.untrackVoiceConnection).not.toHaveBeenCalled();
+		expect(newAdapter.creator).not.toHaveBeenCalled();
+		expect(existingAdapter.sendPayload).toHaveBeenCalledWith(mockPayload);
+		expect(newVoiceConnection).toBe(existingVoiceConnection);
+		expect(stateSetter).not.toHaveBeenCalled();
+	});
+});

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -115,3 +115,36 @@ describe('VoiceConnection#addServerPacket', () => {
 		expect(voiceConnection.configureNetworking).toHaveBeenCalled();
 	});
 });
+
+describe('VoiceConnection#addStatePacket', () => {
+	test('State is assigned to joinConfig', () => {
+		const adapter = createFakeAdapter();
+		const joinConfig = createJoinConfig();
+		const voiceConnection = new VoiceConnection(joinConfig, {
+			debug: false,
+			adapterCreator: adapter.creator,
+		});
+
+		voiceConnection['addStatePacket']({
+			self_deaf: true,
+			self_mute: true,
+			channel_id: '123',
+		} as any);
+
+		expect(voiceConnection.joinConfig).toMatchObject({
+			selfDeaf: true,
+			selfMute: true,
+			channelId: '123',
+		});
+
+		voiceConnection['addStatePacket']({
+			self_mute: false,
+		} as any);
+
+		expect(voiceConnection.joinConfig).toMatchObject({
+			selfDeaf: true,
+			selfMute: false,
+			channelId: '123',
+		});
+	});
+});

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/dot-notation */
 import { createVoiceConnection, VoiceConnection, VoiceConnectionStatus } from '../VoiceConnection';
 import * as _DataStore from '../DataStore';
 jest.mock('../DataStore');
@@ -81,5 +82,36 @@ describe('createVoiceConnection', () => {
 		expect(existingAdapter.sendPayload).toHaveBeenCalledWith(mockPayload);
 		expect(newVoiceConnection).toBe(existingVoiceConnection);
 		expect(stateSetter).not.toHaveBeenCalled();
+	});
+});
+
+describe('VoiceConnection#addServerPacket', () => {
+	test('Stores the packet and attempts to configure networking', () => {
+		const adapter = createFakeAdapter();
+		const joinConfig = createJoinConfig();
+		const voiceConnection = new VoiceConnection(joinConfig, {
+			debug: false,
+			adapterCreator: adapter.creator,
+		});
+		voiceConnection.configureNetworking = jest.fn();
+		const fake = Symbol('fake') as any;
+		voiceConnection['addServerPacket'](fake);
+		expect(voiceConnection['packets'].server).toBe(fake);
+		expect(voiceConnection.configureNetworking).toHaveBeenCalled();
+	});
+
+	test('Overwrites existing packet', () => {
+		const adapter = createFakeAdapter();
+		const joinConfig = createJoinConfig();
+		const voiceConnection = new VoiceConnection(joinConfig, {
+			debug: false,
+			adapterCreator: adapter.creator,
+		});
+		voiceConnection['packets'].server = Symbol('old') as any;
+		voiceConnection.configureNetworking = jest.fn();
+		const fake = Symbol('fake') as any;
+		voiceConnection['addServerPacket'](fake);
+		expect(voiceConnection['packets'].server).toBe(fake);
+		expect(voiceConnection.configureNetworking).toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Implements unit tests for the most important functionality within VoiceConnection. Also includes a minor fix (automatic reconnects done by the library never incremented `reconnectAttempts`, only manual reconnects by the user did)


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
