### PR TITLE
feat: createAudioResource now infers stream type

### DIFF
--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -94,7 +94,9 @@ export class AudioResource<T = unknown> {
  *
  * @param path - The path to validate constraints on
  */
-const VOLUME_CONSTRAINT = (path: Edge[]) => path.some((edge) => edge.type === TransformerType.InlineVolume);
+export const VOLUME_CONSTRAINT = (path: Edge[]) => path.some((edge) => edge.type === TransformerType.InlineVolume);
+
+export const NO_CONSTRAINT = () => true;
 
 /**
  * Tries to infer the type of a stream to aid with transcoder pipelining.
@@ -148,7 +150,7 @@ export function createAudioResource<T>(
 		needsInlineVolume = needsInlineVolume && !analysis.hasVolume;
 	}
 
-	const transformerPipeline = findPipeline(inputType, needsInlineVolume ? VOLUME_CONSTRAINT : () => true);
+	const transformerPipeline = findPipeline(inputType, needsInlineVolume ? VOLUME_CONSTRAINT : NO_CONSTRAINT);
 
 	if (transformerPipeline.length === 0) {
 		if (typeof input === 'string') throw new Error(`Invalid pipeline constructed for string resource '${input}'`);
@@ -159,7 +161,7 @@ export function createAudioResource<T>(
 	if (typeof input !== 'string') streams.unshift(input);
 
 	// the callback is called once the stream ends
-	const playStream = pipeline(streams, noop);
+	const playStream = streams.length > 1 ? pipeline(streams, noop) : streams[0];
 
 	// attempt to find the volume transformer in the pipeline (if one exists)
 	const volume = streams.find((stream) => stream instanceof VolumeTransformer) as VolumeTransformer | undefined;

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -1,7 +1,7 @@
 import { Edge, findPipeline, StreamType, TransformerType } from './TransformerGraph';
 import { pipeline, Readable } from 'stream';
 import { noop } from '../util/util';
-import { VolumeTransformer } from 'prism-media';
+import { VolumeTransformer, opus } from 'prism-media';
 import type { AudioPlayer } from './AudioPlayer';
 
 /**
@@ -97,6 +97,27 @@ export class AudioResource<T = unknown> {
 const VOLUME_CONSTRAINT = (path: Edge[]) => path.some((edge) => edge.type === TransformerType.InlineVolume);
 
 /**
+ * Tries to infer the type of a stream to aid with transcoder pipelining.
+ *
+ * @param stream - The stream to infer the type of
+ */
+export function inferStreamType(
+	stream: Readable,
+): {
+	streamType: StreamType;
+	hasVolume: boolean;
+} {
+	if (stream instanceof opus.Encoder) {
+		return { streamType: StreamType.Opus, hasVolume: false };
+	} else if (stream instanceof opus.Decoder) {
+		return { streamType: StreamType.Raw, hasVolume: false };
+	} else if (stream instanceof VolumeTransformer) {
+		return { streamType: StreamType.Raw, hasVolume: true };
+	}
+	return { streamType: StreamType.Arbitrary, hasVolume: false };
+}
+
+/**
  * Creates an audio resource that can be played be audio players.
  *
  * @remarks
@@ -113,21 +134,26 @@ export function createAudioResource<T>(
 	input: string | Readable,
 	options: CreateAudioResourceOptions<T> = {},
 ): AudioResource<T> {
-	let inputType = options.inputType ?? StreamType.Arbitrary;
+	let inputType = options.inputType;
+	let needsInlineVolume = Boolean(options.inlineVolume);
 
 	// string inputs can only be used with FFmpeg
 	if (typeof input === 'string') {
 		inputType = StreamType.Arbitrary;
+	} else if (typeof inputType === 'undefined') {
+		const analysis = inferStreamType(input);
+		inputType = analysis.streamType;
+		needsInlineVolume = needsInlineVolume && !analysis.hasVolume;
 	}
 
-	const transformerPipeline = findPipeline(inputType, options.inlineVolume ? VOLUME_CONSTRAINT : () => true);
+	const transformerPipeline = findPipeline(inputType, needsInlineVolume ? VOLUME_CONSTRAINT : () => true);
 
 	if (transformerPipeline.length === 0) {
 		if (typeof input === 'string') throw new Error(`Invalid pipeline constructed for string resource '${input}'`);
 		// No adjustments required
 		return new AudioResource([], input, options.metadata);
 	}
-	const streams = transformerPipeline.map((pipe) => pipe.transformer(input));
+	const streams = transformerPipeline.map((edge) => edge.transformer(input));
 	if (typeof input !== 'string') streams.unshift(input);
 
 	// the callback is called once the stream ends

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -117,6 +117,8 @@ export function inferStreamType(
 		return { streamType: StreamType.Raw, hasVolume: true };
 	} else if (stream instanceof opus.OggDemuxer) {
 		return { streamType: StreamType.Opus, hasVolume: false };
+	} else if (stream instanceof opus.WebmDemuxer) {
+		return { streamType: StreamType.Opus, hasVolume: false };
 	}
 	return { streamType: StreamType.Arbitrary, hasVolume: false };
 }

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -113,6 +113,8 @@ export function inferStreamType(
 		return { streamType: StreamType.Raw, hasVolume: false };
 	} else if (stream instanceof VolumeTransformer) {
 		return { streamType: StreamType.Raw, hasVolume: true };
+	} else if (stream instanceof opus.OggDemuxer) {
+		return { streamType: StreamType.Opus, hasVolume: false };
 	}
 	return { streamType: StreamType.Arbitrary, hasVolume: false };
 }

--- a/src/audio/__tests__/AudioResource.test.ts
+++ b/src/audio/__tests__/AudioResource.test.ts
@@ -81,4 +81,10 @@ describe('createAudioResource', () => {
 		expect(findPipeline).toHaveBeenCalledWith(StreamType.Raw, NO_CONSTRAINT);
 		expect(resource.volume).toBe(stream);
 	});
+
+	test('Falls back to Arbitrary for unknown stream type', () => {
+		const resource = createAudioResource(new PassThrough());
+		expect(findPipeline).toHaveBeenCalledWith(StreamType.Arbitrary, NO_CONSTRAINT);
+		expect(resource.volume).toBeUndefined();
+	});
 });

--- a/src/audio/__tests__/AudioResource.test.ts
+++ b/src/audio/__tests__/AudioResource.test.ts
@@ -5,7 +5,7 @@ import { Edge, findPipeline as _findPipeline, StreamType, TransformerType } from
 jest.mock('prism-media');
 jest.mock('../TransformerGraph');
 
-const findPipeline = (_findPipeline as unknown) as jest.Mock<typeof _findPipeline>;
+const findPipeline = (_findPipeline as unknown) as jest.MockedFunction<typeof _findPipeline>;
 
 beforeEach(() => {
 	findPipeline.mockReset();

--- a/src/audio/__tests__/AudioResource.test.ts
+++ b/src/audio/__tests__/AudioResource.test.ts
@@ -1,3 +1,4 @@
+import { opus, VolumeTransformer } from 'prism-media';
 import { PassThrough } from 'stream';
 import { createAudioResource, NO_CONSTRAINT, VOLUME_CONSTRAINT } from '../AudioResource';
 import { Edge, findPipeline as _findPipeline, StreamType, TransformerType } from '../TransformerGraph';
@@ -7,8 +8,7 @@ jest.mock('../TransformerGraph');
 
 const findPipeline = (_findPipeline as unknown) as jest.MockedFunction<typeof _findPipeline>;
 
-beforeEach(() => {
-	findPipeline.mockReset();
+beforeAll(() => {
 	findPipeline.mockImplementation((from: StreamType, constraint: (path: Edge[]) => boolean) => {
 		const base = [
 			{
@@ -20,7 +20,7 @@ beforeEach(() => {
 		if (constraint === VOLUME_CONSTRAINT) {
 			base.push({
 				cost: 1,
-				transformer: () => new PassThrough(),
+				transformer: () => new VolumeTransformer({} as any),
 				type: TransformerType.InlineVolume,
 			});
 		}
@@ -28,10 +28,57 @@ beforeEach(() => {
 	});
 });
 
+beforeEach(() => {
+	findPipeline.mockClear();
+});
+
 describe('createAudioResource', () => {
 	test('Creates a resource from string path', () => {
 		const resource = createAudioResource('mypath.mp3');
 		expect(findPipeline).toHaveBeenCalledWith(StreamType.Arbitrary, NO_CONSTRAINT);
 		expect(resource.volume).toBeUndefined();
+	});
+
+	test('Creates a resource from string path (volume)', () => {
+		const resource = createAudioResource('mypath.mp3', { inlineVolume: true });
+		expect(findPipeline).toHaveBeenCalledWith(StreamType.Arbitrary, VOLUME_CONSTRAINT);
+		expect(resource.volume).toBeInstanceOf(VolumeTransformer);
+	});
+
+	test('Only infers type if not explicitly given', () => {
+		const resource = createAudioResource(new opus.Encoder(), { inputType: StreamType.Arbitrary });
+		expect(findPipeline).toHaveBeenCalledWith(StreamType.Arbitrary, NO_CONSTRAINT);
+		expect(resource.volume).toBeUndefined();
+	});
+
+	test('Infers from opus.Encoder', () => {
+		const resource = createAudioResource(new opus.Encoder(), { inlineVolume: true });
+		expect(findPipeline).toHaveBeenCalledWith(StreamType.Opus, VOLUME_CONSTRAINT);
+		expect(resource.volume).toBeInstanceOf(VolumeTransformer);
+	});
+
+	test('Infers from opus.OggDemuxer', () => {
+		const resource = createAudioResource(new opus.OggDemuxer());
+		expect(findPipeline).toHaveBeenCalledWith(StreamType.Opus, NO_CONSTRAINT);
+		expect(resource.volume).toBeUndefined();
+	});
+
+	test('Infers from opus.WebmDemuxer', () => {
+		const resource = createAudioResource(new opus.WebmDemuxer());
+		expect(findPipeline).toHaveBeenCalledWith(StreamType.Opus, NO_CONSTRAINT);
+		expect(resource.volume).toBeUndefined();
+	});
+
+	test('Infers from opus.Decoder', () => {
+		const resource = createAudioResource(new opus.Decoder());
+		expect(findPipeline).toHaveBeenCalledWith(StreamType.Raw, NO_CONSTRAINT);
+		expect(resource.volume).toBeUndefined();
+	});
+
+	test('Infers from VolumeTransformer', () => {
+		const stream = new VolumeTransformer({} as any);
+		const resource = createAudioResource(stream, { inlineVolume: true });
+		expect(findPipeline).toHaveBeenCalledWith(StreamType.Raw, NO_CONSTRAINT);
+		expect(resource.volume).toBe(stream);
 	});
 });

--- a/src/audio/__tests__/AudioResource.test.ts
+++ b/src/audio/__tests__/AudioResource.test.ts
@@ -1,0 +1,37 @@
+import { PassThrough } from 'stream';
+import { createAudioResource, NO_CONSTRAINT, VOLUME_CONSTRAINT } from '../AudioResource';
+import { Edge, findPipeline as _findPipeline, StreamType, TransformerType } from '../TransformerGraph';
+
+jest.mock('prism-media');
+jest.mock('../TransformerGraph');
+
+const findPipeline = (_findPipeline as unknown) as jest.Mock<typeof _findPipeline>;
+
+beforeEach(() => {
+	findPipeline.mockReset();
+	findPipeline.mockImplementation((from: StreamType, constraint: (path: Edge[]) => boolean) => {
+		const base = [
+			{
+				cost: 1,
+				transformer: () => new PassThrough(),
+				type: TransformerType.FFmpegPCM,
+			},
+		];
+		if (constraint === VOLUME_CONSTRAINT) {
+			base.push({
+				cost: 1,
+				transformer: () => new PassThrough(),
+				type: TransformerType.InlineVolume,
+			});
+		}
+		return base as any[];
+	});
+});
+
+describe('createAudioResource', () => {
+	test('Creates a resource from string path', () => {
+		const resource = createAudioResource('mypath.mp3');
+		expect(findPipeline).toHaveBeenCalledWith(StreamType.Arbitrary, NO_CONSTRAINT);
+		expect(resource.volume).toBeUndefined();
+	});
+});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #83. Simplifies playing streams with specific types, keeping any optimisations in the transcoder pipeline:

```ts
// old
createAudioResource(raw.pipe(new prism.opus.Encoder(options)), { inputType: StreamType.Opus });
createAudioResource(opus.pipe(new prism.opus.Decoder(options)), { inputType: StreamType.Raw });
createAudioResource(ogg.pipe(new prism.opus.OggDemuxer()), { inputType: StreamType.Opus });

// new
createAudioResource(raw.pipe(new prism.opus.Encoder(options)));
createAudioResource(opus.pipe(new prism.opus.Decoder(options)));
createAudioResource(ogg.pipe(new prism.opus.OggDemuxer()));
```

Additionally, if you specify `inlineVolume` as true and pass in a prism-media VolumeTransformer, the pipeline will just re-use the input VolumeTransformer rather than creating a new one to improve performance.


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
