### PR TITLE
feat: keep alive mechanism to detect connectivity to Discord

### DIFF
--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -485,21 +485,27 @@ export class VoiceConnection extends (EventEmitter as new () => TypedEmitter<Voi
 	}
 
 	/**
-	 * The latest ping (in milliseconds) for the WebSocket connection for this voice connection, if this
-	 * data is available.
+	 * The latest ping (in milliseconds) for the WebSocket connection and audio playback for this voice
+	 * connection, if this data is available.
 	 *
 	 * @remarks
 	 * For this data to be available, the VoiceConnection must be in the Ready state, and its underlying
-	 * WebSocket connection must have had at least one ping-pong exchange.
+	 * WebSocket connection and UDP socket must have had at least one ping-pong exchange.
 	 */
 	public get ping() {
 		if (
 			this.state.status === VoiceConnectionStatus.Ready &&
-			this.state.networking.state.code === NetworkingStatusCode.Ready &&
-			typeof this.state.networking.state.ws.ping !== 'undefined'
+			this.state.networking.state.code === NetworkingStatusCode.Ready
 		) {
-			return this.state.networking.state.ws.ping;
+			return {
+				ws: this.state.networking.state.ws.ping,
+				udp: this.state.networking.state.udp.ping,
+			};
 		}
+		return {
+			ws: undefined,
+			udp: undefined,
+		};
 	}
 
 	/**

--- a/src/networking/Networking.ts
+++ b/src/networking/Networking.ts
@@ -171,6 +171,7 @@ export class Networking extends EventEmitter {
 		this.onWsPacket = this.onWsPacket.bind(this);
 		this.onWsClose = this.onWsClose.bind(this);
 		this.onWsDebug = this.onWsDebug.bind(this);
+		this.onUdpDebug = this.onUdpDebug.bind(this);
 		this.onUdpClose = this.onUdpClose.bind(this);
 
 		this.debug = debug ? this.emit.bind(this, 'debug') : null;
@@ -222,6 +223,7 @@ export class Networking extends EventEmitter {
 			oldUdp.on('error', noop);
 			oldUdp.off('error', this.onChildError);
 			oldUdp.off('close', this.onUdpClose);
+			oldUdp.off('debug', this.onUdpDebug);
 			oldUdp.destroy();
 		}
 
@@ -344,6 +346,7 @@ export class Networking extends EventEmitter {
 
 			const udp = new VoiceUDPSocket({ ip, port });
 			udp.on('error', this.onChildError);
+			udp.on('debug', this.onUdpDebug);
 			udp.once('close', this.onUdpClose);
 			udp
 				.performIPDiscovery(ssrc)
@@ -410,6 +413,15 @@ export class Networking extends EventEmitter {
 	 */
 	private onWsDebug(message: string) {
 		this.debug?.(`[WS] ${message}`);
+	}
+
+	/**
+	 * Propagates debug messages from the child UDPSocket.
+	 *
+	 * @param message - The emitted debug message
+	 */
+	private onUdpDebug(message: string) {
+		this.debug?.(`[UDP] ${message}`);
 	}
 
 	/**

--- a/src/networking/Networking.ts
+++ b/src/networking/Networking.ts
@@ -171,6 +171,7 @@ export class Networking extends EventEmitter {
 		this.onWsPacket = this.onWsPacket.bind(this);
 		this.onWsClose = this.onWsClose.bind(this);
 		this.onWsDebug = this.onWsDebug.bind(this);
+		this.onUdpClose = this.onUdpClose.bind(this);
 
 		this.debug = debug ? this.emit.bind(this, 'debug') : null;
 
@@ -220,6 +221,7 @@ export class Networking extends EventEmitter {
 		if (oldUdp && oldUdp !== newUdp) {
 			oldUdp.on('error', noop);
 			oldUdp.off('error', this.onChildError);
+			oldUdp.off('close', this.onUdpClose);
 			oldUdp.destroy();
 		}
 
@@ -318,6 +320,19 @@ export class Networking extends EventEmitter {
 	}
 
 	/**
+	 * Called when the UDP socket has closed itself if it has stopped receiving replies from Discord
+	 */
+	private onUdpClose() {
+		if (this.state.code === NetworkingStatusCode.Ready) {
+			this.state = {
+				...this.state,
+				code: NetworkingStatusCode.Resuming,
+				ws: this.createWebSocket(this.state.connectionOptions.endpoint),
+			};
+		}
+	}
+
+	/**
 	 * Called when a packet is received on the connection's WebSocket
 	 * @param packet - The received packet
 	 */
@@ -329,6 +344,7 @@ export class Networking extends EventEmitter {
 
 			const udp = new VoiceUDPSocket({ ip, port });
 			udp.on('error', this.onChildError);
+			udp.once('close', this.onUdpClose);
 			udp
 				.performIPDiscovery(ssrc)
 				.then((localConfig) => {

--- a/src/networking/VoiceUDPSocket.ts
+++ b/src/networking/VoiceUDPSocket.ts
@@ -80,6 +80,7 @@ export class VoiceUDPSocket extends EventEmitter {
 		this.socket = createSocket('udp4');
 		this.socket.on('error', (error: Error) => this.emit('error', error));
 		this.socket.on('message', (buffer: Buffer) => this.onMessage(buffer));
+		this.socket.on('close', () => this.emit('close'));
 		this.remote = remote;
 		this.keepAlives = [];
 		this.keepAliveBuffer = Buffer.alloc(8);
@@ -108,8 +109,8 @@ export class VoiceUDPSocket extends EventEmitter {
 	 */
 	private keepAlive() {
 		if (this.keepAlives.length >= KEEP_ALIVE_LIMIT) {
-			this.emit('error', new Error('UDP: Unable to ping Discord - connection has likely been lost'));
-			clearInterval(this.keepAliveInterval);
+			this.destroy();
+			return;
 		}
 
 		this.keepAliveBuffer.writeUInt32LE(this.keepAliveCounter, 0);

--- a/src/networking/VoiceUDPSocket.ts
+++ b/src/networking/VoiceUDPSocket.ts
@@ -1,7 +1,6 @@
 import { createSocket, Socket } from 'dgram';
 import { EventEmitter } from 'events';
 import { isIPv4 } from 'net';
-import { clearInterval } from 'timers';
 
 /**
  * Stores an IP address and port. Used to store socket details for the local client as well as

--- a/src/networking/VoiceUDPSocket.ts
+++ b/src/networking/VoiceUDPSocket.ts
@@ -71,11 +71,16 @@ export class VoiceUDPSocket extends EventEmitter {
 	public ping?: number;
 
 	/**
+	 * The debug logger function, if debugging is enabled.
+	 */
+	private readonly debug: null | ((message: string) => void);
+
+	/**
 	 * Creates a new VoiceUDPSocket.
 	 *
 	 * @param remote - Details of the remote socket
 	 */
-	public constructor(remote: SocketConfig) {
+	public constructor(remote: SocketConfig, debug = false) {
 		super();
 		this.socket = createSocket('udp4');
 		this.socket.on('error', (error: Error) => this.emit('error', error));
@@ -86,6 +91,8 @@ export class VoiceUDPSocket extends EventEmitter {
 		this.keepAliveBuffer = Buffer.alloc(8);
 		this.keepAliveInterval = setInterval(() => this.keepAlive(), KEEP_ALIVE_INTERVAL);
 		setImmediate(() => this.keepAlive());
+
+		this.debug = debug ? this.emit.bind(this, 'debug') : null;
 	}
 
 	/**
@@ -109,6 +116,7 @@ export class VoiceUDPSocket extends EventEmitter {
 	 */
 	private keepAlive() {
 		if (this.keepAlives.length >= KEEP_ALIVE_LIMIT) {
+			this.debug?.('UDP socket has not received enough responses from Discord - closing socket');
 			this.destroy();
 			return;
 		}

--- a/src/networking/VoiceUDPSocket.ts
+++ b/src/networking/VoiceUDPSocket.ts
@@ -85,14 +85,14 @@ export class VoiceUDPSocket extends EventEmitter {
  */
 export function parseLocalPacket(message: Buffer): SocketConfig {
 	const packet = Buffer.from(message);
-	let ip = '';
-	for (let i = 4; i < packet.indexOf(0, i); i++) ip += String.fromCharCode(packet[i]);
+
+	const ip = packet.slice(4, packet.indexOf(0, 4)).toString('utf-8');
 
 	if (!isIPv4(ip)) {
 		throw new Error('Malformed IP address');
 	}
 
-	const port = parseInt(packet.readUIntLE(packet.length - 2, 2).toString(10), 10);
+	const port = packet.readUInt16LE(packet.length - 2);
 
 	return { ip, port };
 }

--- a/src/networking/VoiceUDPSocket.ts
+++ b/src/networking/VoiceUDPSocket.ts
@@ -99,7 +99,6 @@ export class VoiceUDPSocket extends EventEmitter {
 			const index = this.keepAlives.findIndex(({ value }) => value === counter);
 			if (index === -1) return;
 			this.ping = Date.now() - this.keepAlives[index].timestamp;
-			console.log(this.ping);
 			// Delete all keep alives up to and including the received one
 			this.keepAlives.splice(0, index);
 		}

--- a/src/networking/__tests__/VoiceUDPSocket.test.ts
+++ b/src/networking/__tests__/VoiceUDPSocket.test.ts
@@ -26,6 +26,12 @@ const VALID_RESPONSE = Buffer.concat([
 ]);
 
 describe('VoiceUDPSocket#performIPDiscovery', () => {
+	let socket: VoiceUDPSocket;
+
+	afterEach(() => {
+		socket.destroy();
+	});
+
 	/*
 		Ensures that the UDP socket sends data and parses the response correctly
 	*/
@@ -35,7 +41,7 @@ describe('VoiceUDPSocket#performIPDiscovery', () => {
 			fake.emit('message', VALID_RESPONSE);
 		});
 		createSocket.mockImplementation((type) => fake as any);
-		const socket = new VoiceUDPSocket({ ip: '1.2.3.4', port: 25565 });
+		socket = new VoiceUDPSocket({ ip: '1.2.3.4', port: 25565 });
 
 		expect(createSocket).toHaveBeenCalledWith('udp4');
 		await expect(socket.performIPDiscovery(1234)).resolves.toEqual({
@@ -58,7 +64,7 @@ describe('VoiceUDPSocket#performIPDiscovery', () => {
 			setImmediate(() => fake.emit('message', VALID_RESPONSE));
 		});
 		createSocket.mockImplementation((type) => fake as any);
-		const socket = new VoiceUDPSocket({ ip: '1.2.3.4', port: 25565 });
+		socket = new VoiceUDPSocket({ ip: '1.2.3.4', port: 25565 });
 
 		expect(createSocket).toHaveBeenCalledWith('udp4');
 		await expect(socket.performIPDiscovery(1234)).resolves.toEqual({
@@ -75,7 +81,7 @@ describe('VoiceUDPSocket#performIPDiscovery', () => {
 			setImmediate(() => fake.close());
 		});
 		createSocket.mockImplementation((type) => fake as any);
-		const socket = new VoiceUDPSocket({ ip: '1.2.3.4', port: 25565 });
+		socket = new VoiceUDPSocket({ ip: '1.2.3.4', port: 25565 });
 
 		expect(createSocket).toHaveBeenCalledWith('udp4');
 		await expect(socket.performIPDiscovery(1234)).rejects.toThrowError();

--- a/src/networking/__tests__/VoiceUDPSocket.test.ts
+++ b/src/networking/__tests__/VoiceUDPSocket.test.ts
@@ -101,15 +101,15 @@ describe('VoiceUDPSocket#performIPDiscovery', () => {
 		createSocket.mockImplementation(() => fake as any);
 		socket = new VoiceUDPSocket({ ip: '1.2.3.4', port: 25565 });
 
-		let errorCount = 0;
-		socket.on('error', () => errorCount++);
+		let closed = false;
+		socket.on('close', () => (closed = true));
 
 		for (let i = 0; i < 30; i++) {
 			jest.advanceTimersToNextTimer();
 			await wait();
 		}
 
-		expect(errorCount).toBe(0);
+		expect(closed).toBe(false);
 	});
 
 	test('Emits an error when no response received to keep alive messages', async () => {
@@ -118,15 +118,15 @@ describe('VoiceUDPSocket#performIPDiscovery', () => {
 		createSocket.mockImplementation(() => fake as any);
 		socket = new VoiceUDPSocket({ ip: '1.2.3.4', port: 25565 });
 
-		let errorCount = 0;
-		socket.on('error', () => errorCount++);
+		let closed = false;
+		socket.on('close', () => (closed = true));
 
 		for (let i = 0; i < 15; i++) {
 			jest.advanceTimersToNextTimer();
 			await wait();
 		}
 
-		expect(errorCount).toBe(1);
+		expect(closed).toBe(true);
 	});
 
 	test('Recovers from intermittent responses', async () => {
@@ -136,19 +136,19 @@ describe('VoiceUDPSocket#performIPDiscovery', () => {
 		createSocket.mockImplementation(() => fake as any);
 		socket = new VoiceUDPSocket({ ip: '1.2.3.4', port: 25565 });
 
-		let errorCount = 0;
-		socket.on('error', () => errorCount++);
+		let closed = false;
+		socket.on('close', () => (closed = true));
 
 		for (let i = 0; i < 10; i++) {
 			jest.advanceTimersToNextTimer();
 			await wait();
 		}
 		fakeSend.mockImplementation((buffer: Buffer) => process.nextTick(() => fake.emit('message', buffer)));
-		expect(errorCount).toBe(0);
+		expect(closed).toBe(false);
 		for (let i = 0; i < 30; i++) {
 			jest.advanceTimersToNextTimer();
 			await wait();
 		}
-		expect(errorCount).toBe(0);
+		expect(closed).toBe(false);
 	});
 });

--- a/src/networking/__tests__/VoiceUDPSocket.test.ts
+++ b/src/networking/__tests__/VoiceUDPSocket.test.ts
@@ -44,12 +44,13 @@ describe('VoiceUDPSocket#performIPDiscovery', () => {
 		socket = new VoiceUDPSocket({ ip: '1.2.3.4', port: 25565 });
 
 		expect(createSocket).toHaveBeenCalledWith('udp4');
+		expect(fake.listenerCount('message')).toBe(1);
 		await expect(socket.performIPDiscovery(1234)).resolves.toEqual({
 			ip: '94.195.157.2',
 			port: 42381,
 		});
 		// Ensure clean up occurs
-		expect(fake.listenerCount('message')).toBe(0);
+		expect(fake.listenerCount('message')).toBe(1);
 	});
 
 	/*
@@ -67,12 +68,13 @@ describe('VoiceUDPSocket#performIPDiscovery', () => {
 		socket = new VoiceUDPSocket({ ip: '1.2.3.4', port: 25565 });
 
 		expect(createSocket).toHaveBeenCalledWith('udp4');
+		expect(fake.listenerCount('message')).toBe(1);
 		await expect(socket.performIPDiscovery(1234)).resolves.toEqual({
 			ip: '94.195.157.2',
 			port: 42381,
 		});
 		// Ensure clean up occurs
-		expect(fake.listenerCount('message')).toBe(0);
+		expect(fake.listenerCount('message')).toBe(1);
 	});
 
 	test('Rejects if socket closes before IP discovery can be completed', async () => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds a keep alive mechanism to the UDP socket, that allows 60 seconds for Discord to echo keep alive messages back to the sender. If 60 seconds pass, the UDP socket emits an error warning that a connection between the client and Discord is likely unavailable, causing the voice connection to attempt to reconnect.

A breaking change because `connection.ping` is now of type ` { ws: ?number, udp: ?number }` instead of just `?number`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)