### PR TITLE
feat: use typed event emitters internally

### DIFF
--- a/src/networking/VoiceUDPSocket.ts
+++ b/src/networking/VoiceUDPSocket.ts
@@ -1,6 +1,7 @@
 import { createSocket, Socket } from 'dgram';
 import { EventEmitter } from 'events';
 import { isIPv4 } from 'net';
+import TypedEmitter from 'typed-emitter';
 
 /**
  * Stores an IP address and port. Used to store socket details for the local client as well as
@@ -14,6 +15,13 @@ export interface SocketConfig {
 interface KeepAlive {
 	value: number;
 	timestamp: number;
+}
+
+export interface VoiceUDPSocketEvents {
+	error: (error: Error) => void;
+	close: () => void;
+	debug: (message: string) => void;
+	message: (message: Buffer) => void;
 }
 
 /**
@@ -34,7 +42,7 @@ const MAX_COUNTER_VALUE = 2 ** 32 - 1;
 /**
  * Manages the UDP networking for a voice connection.
  */
-export class VoiceUDPSocket extends EventEmitter {
+export class VoiceUDPSocket extends (EventEmitter as new () => TypedEmitter<VoiceUDPSocketEvents>) {
 	/**
 	 * The underlying network Socket for the VoiceUDPSocket.
 	 */
@@ -92,7 +100,7 @@ export class VoiceUDPSocket extends EventEmitter {
 		this.keepAliveInterval = setInterval(() => this.keepAlive(), KEEP_ALIVE_INTERVAL);
 		setImmediate(() => this.keepAlive());
 
-		this.debug = debug ? this.emit.bind(this, 'debug') : null;
+		this.debug = debug ? (message: string) => this.emit('debug', message) : null;
 	}
 
 	/**

--- a/src/networking/VoiceWebSocket.ts
+++ b/src/networking/VoiceWebSocket.ts
@@ -1,6 +1,7 @@
 import { VoiceOPCodes } from 'discord-api-types/v8/gateway';
 import EventEmitter from 'events';
 import WebSocket, { MessageEvent } from 'ws';
+import TypedEmitter from 'typed-emitter';
 
 /**
  * Debug event for VoiceWebSocket.
@@ -9,11 +10,19 @@ import WebSocket, { MessageEvent } from 'ws';
  * @type {string}
  */
 
+export interface VoiceWebSocketEvents {
+	error: (error: WebSocket.ErrorEvent) => void;
+	open: (event: WebSocket.OpenEvent) => void;
+	close: (event: WebSocket.CloseEvent) => void;
+	debug: (message: string) => void;
+	packet: (packet: any) => void;
+}
+
 /**
  * An extension of the WebSocket class to provide helper functionality when interacting
  * with the Discord Voice gateway.
  */
-export class VoiceWebSocket extends EventEmitter {
+export class VoiceWebSocket extends (EventEmitter as new () => TypedEmitter<VoiceWebSocketEvents>) {
 	/**
 	 * The current heartbeat interval, if any
 	 */
@@ -67,7 +76,7 @@ export class VoiceWebSocket extends EventEmitter {
 		this.lastHeartbeatAck = 0;
 		this.lastHeatbeatSend = 0;
 
-		this.debug = debug ? this.emit.bind(this, 'debug') : null;
+		this.debug = debug ? (message: string) => this.emit('debug', message) : null;
 	}
 
 	/**

--- a/src/networking/VoiceWebSocket.ts
+++ b/src/networking/VoiceWebSocket.ts
@@ -11,7 +11,7 @@ import TypedEmitter from 'typed-emitter';
  */
 
 export interface VoiceWebSocketEvents {
-	error: (error: WebSocket.ErrorEvent) => void;
+	error: (error: Error) => void;
 	open: (event: WebSocket.OpenEvent) => void;
 	close: (event: WebSocket.CloseEvent) => void;
 	debug: (message: string) => void;
@@ -70,7 +70,7 @@ export class VoiceWebSocket extends (EventEmitter as new () => TypedEmitter<Voic
 		this.ws = new WebSocket(address);
 		this.ws.onmessage = (e) => this.onMessage(e);
 		this.ws.onopen = (e) => this.emit('open', e);
-		this.ws.onerror = (e) => this.emit('error', e);
+		this.ws.onerror = (e: Error | WebSocket.ErrorEvent) => this.emit('error', e instanceof Error ? e : e.error);
 		this.ws.onclose = (e) => this.emit('close', e);
 
 		this.lastHeartbeatAck = 0;

--- a/src/networking/__tests__/VoiceWebSocket.test.ts
+++ b/src/networking/__tests__/VoiceWebSocket.test.ts
@@ -75,7 +75,7 @@ describe('VoiceWebSocket: event propagation', () => {
 		const ws = new VoiceWebSocket(endpoint, false);
 		await server.connected;
 		const rcvError = once(ws, 'error');
-		const rcvClose = onceIgnoreError(ws, 'error');
+		const rcvClose = onceIgnoreError(ws, 'close');
 		server.error();
 		await expect(rcvError).resolves.toBeTruthy();
 		await expect(rcvClose).resolves.toBeTruthy();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Refactors the library to use typed event emitters internally. Also fixes an inaccuracy within a test, as well as fixing an error emission bug in `VoiceWebSocket`.


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
