### PR TITLE
fix(AudioPlayer): enter Buffering state for resources that are not yet readable

### DIFF
--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -356,7 +356,7 @@ export class AudioPlayer extends (EventEmitter as new () => TypedEmitter<AudioPl
 
 		resource.playStream.once('error', onStreamError);
 
-		if (resource.playStream.readable) {
+		if (resource.started) {
 			this.state = {
 				status: AudioPlayerStatus.Playing,
 				missedFrames: 0,

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -1,5 +1,5 @@
 import { Edge, findPipeline, StreamType, TransformerType } from './TransformerGraph';
-import { pipeline, Readable } from 'stream';
+import { once, pipeline, Readable } from 'stream';
 import { noop } from '../util/util';
 import { VolumeTransformer, opus } from 'prism-media';
 import type { AudioPlayer } from './AudioPlayer';
@@ -68,11 +68,20 @@ export class AudioResource<T = unknown> {
 	 */
 	public playbackDuration = 0;
 
+	/**
+	 * Whether or not the stream for this resource has started (data has become readable)
+	 */
+	public started = false;
+
 	public constructor(pipeline: Edge[], playStream: Readable, metadata?: T, volume?: VolumeTransformer) {
 		this.pipeline = pipeline;
 		this.playStream = playStream;
 		this.metadata = metadata;
 		this.volume = volume;
+
+		once(this.playStream, 'readable')
+			.then(() => (this.started = true))
+			.catch(noop);
 	}
 
 	/**

--- a/src/audio/__tests__/AudioPlayer.test.ts
+++ b/src/audio/__tests__/AudioPlayer.test.ts
@@ -41,6 +41,13 @@ function wait() {
 	return new Promise((resolve) => process.nextTick(resolve));
 }
 
+async function makeReadable(resource: AudioResource) {
+	while (!resource.started) {
+		await wait();
+	}
+	return resource;
+}
+
 let player: AudioPlayer | undefined;
 
 beforeEach(() => {
@@ -62,9 +69,9 @@ describe('State transitions', () => {
 		expect(deleteAudioPlayerMock).toBeCalledTimes(0);
 	});
 
-	test('Playing resource with pausing and resuming', () => {
+	test('Playing resource with pausing and resuming', async () => {
 		// Call AudioResource constructor directly to avoid analysing pipeline for stream
-		const resource = new AudioResource([], Readable.from(silence()));
+		const resource = await makeReadable(new AudioResource([], Readable.from(silence())));
 		player = createAudioPlayer();
 		expect(player.state.status).toBe(AudioPlayerStatus.Idle);
 
@@ -75,7 +82,6 @@ describe('State transitions', () => {
 		expect(player.state.status).toBe(AudioPlayerStatus.Idle);
 		expect(addAudioPlayerMock).toBeCalledTimes(0);
 
-		// Expect to be in the Playing state after calling .play() with a readable resource
 		player.play(resource);
 		expect(player.state.status).toBe(AudioPlayerStatus.Playing);
 		expect(addAudioPlayerMock).toBeCalledTimes(1);
@@ -100,8 +106,8 @@ describe('State transitions', () => {
 		expect(deleteAudioPlayerMock).toBeCalledTimes(0);
 	});
 
-	test('Playing to Stopping', () => {
-		const resource = new AudioResource([], Readable.from(silence()));
+	test('Playing to Stopping', async () => {
+		const resource = await makeReadable(new AudioResource([], Readable.from(silence())));
 		player = createAudioPlayer();
 
 		// stop() shouldn't do anything in Idle state
@@ -120,13 +126,13 @@ describe('State transitions', () => {
 	});
 
 	describe('NoSubscriberBehavior transitions', () => {
-		test('NoSubscriberBehavior.Pause', () => {
+		test('NoSubscriberBehavior.Pause', async () => {
 			const connection = createVoiceConnectionMock();
 			if (connection.state.status !== VoiceConnectionStatus.Signalling) {
 				throw new Error('Voice connection should have been Signalling');
 			}
 
-			const resource = new AudioResource([], Readable.from(silence()));
+			const resource = await makeReadable(new AudioResource([], Readable.from(silence())));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Pause } });
 			connection.subscribe(player);
 
@@ -146,8 +152,8 @@ describe('State transitions', () => {
 			expect(player.state.status).toBe(AudioPlayerStatus.Playing);
 		});
 
-		test('NoSubscriberBehavior.Play', () => {
-			const resource = new AudioResource([], Readable.from(silence()));
+		test('NoSubscriberBehavior.Play', async () => {
+			const resource = await makeReadable(new AudioResource([], Readable.from(silence())));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Play } });
 
 			player.play(resource);
@@ -156,8 +162,8 @@ describe('State transitions', () => {
 			expect(player.state.status).toBe(AudioPlayerStatus.Playing);
 		});
 
-		test('NoSubscriberBehavior.Stop', () => {
-			const resource = new AudioResource([], Readable.from(silence()));
+		test('NoSubscriberBehavior.Stop', async () => {
+			const resource = await makeReadable(new AudioResource([], Readable.from(silence())));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Stop } });
 
 			player.play(resource);
@@ -181,8 +187,7 @@ describe('State transitions', () => {
 		};
 
 		const buffer = Buffer.from([1, 2, 4, 8]);
-		const resource = new AudioResource([], Readable.from([buffer, buffer, buffer, buffer, buffer]));
-		resource.playStream.read(); // To start the stream
+		const resource = await makeReadable(new AudioResource([], Readable.from([buffer, buffer, buffer, buffer, buffer])));
 		player = createAudioPlayer();
 		connection.subscribe(player);
 
@@ -300,7 +305,7 @@ test('play() throws when playing a resource that has already ended', async () =>
 });
 
 test('Propagates errors from streams', async () => {
-	const resource = new AudioResource([], Readable.from(silence()));
+	const resource = await makeReadable(new AudioResource([], Readable.from(silence())));
 	player = createAudioPlayer();
 	player.play(resource);
 	expect(player.state.status).toBe(AudioPlayerStatus.Playing);

--- a/src/audio/__tests__/AudioPlayer.test.ts
+++ b/src/audio/__tests__/AudioPlayer.test.ts
@@ -131,12 +131,11 @@ describe('State transitions', () => {
 
 		player.play(resource);
 		expect(player.state.status).toBe(AudioPlayerStatus.Buffering);
-		expect(addAudioPlayerMock).toBeCalledTimes(1);
 
 		await started(resource);
 
 		expect(player.state.status).toBe(AudioPlayerStatus.Playing);
-		expect(addAudioPlayerMock).toBeCalledTimes(2);
+		expect(addAudioPlayerMock).toHaveBeenCalled();
 		expect(deleteAudioPlayerMock).not.toHaveBeenCalled();
 	});
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #97.

If an AudioResource does not immediately have data to read when it is added to an AudioPlayer, then the player will enter a Buffering state and wait until the resource _does_ have data to read, at which point it will enter the Playing state.

Existing tests were updated to wait for a resource to have data until playing them, and a new test has been added to test this behaviour.

**Status and versioning classification:**

Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)