### PR TITLE
fix(VoiceConnection): handle nullable endpoint in voice server update payload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3126,9 +3126,9 @@
 			}
 		},
 		"discord-api-types": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.12.1.tgz",
-			"integrity": "sha512-x8dhQqPZUtIEKjDHMdA6D3aAsZUMoeo58fAgFA5WOAdSh+uVyRsvny4+25b+RIRasG2Zf2UpDUsx8NKO5zk/6g==",
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.15.1.tgz",
+			"integrity": "sha512-f9HuqxQddQxaB1ZAdsGTvHdhUK23RhZLdU50CNNpV3NsThvlqvbo3fQAKJzkbrBD95BQMklasrDqBNs+p03k5Q==",
 			"dev": true
 		},
 		"doctrine": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"@typescript-eslint/eslint-plugin": "^4.14.2",
 		"@typescript-eslint/parser": "^4.14.2",
 		"babel-jest": "^26.6.3",
-		"discord-api-types": "^0.12.1",
+		"discord-api-types": "^0.15.1",
 		"eslint": "^7.20.0",
 		"eslint-config-marine": "^8.1.0",
 		"eslint-config-prettier": "^7.2.0",

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -1,4 +1,4 @@
-import { GatewayOPCodes } from 'discord-api-types/v8/gateway';
+import { GatewayOPCodes } from 'discord-api-types/v8';
 import { AudioPlayer } from './audio';
 import { VoiceConnection } from './VoiceConnection';
 

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -247,6 +247,7 @@ export class VoiceConnection extends (EventEmitter as new () => TypedEmitter<Voi
 			this.state = {
 				...this.state,
 				status: VoiceConnectionStatus.Disconnected,
+				closeCode: undefined,
 			};
 		}
 	}

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -63,7 +63,7 @@ export interface VoiceConnectionDisconnectedState {
 	/**
 	 * The close code of the WebSocket connection to the Discord voice server.
 	 */
-	closeCode: number;
+	closeCode?: number;
 	subscription?: PlayerSubscription;
 	adapter: DiscordGatewayAdapterImplementerMethods;
 }
@@ -241,7 +241,14 @@ export class VoiceConnection extends (EventEmitter as new () => TypedEmitter<Voi
 	 */
 	private addServerPacket(packet: GatewayVoiceServerUpdateDispatchData) {
 		this.packets.server = packet;
-		this.configureNetworking();
+		if (packet.endpoint) {
+			this.configureNetworking();
+		} else if (this.state.status !== VoiceConnectionStatus.Destroyed) {
+			this.state = {
+				...this.state,
+				status: VoiceConnectionStatus.Disconnected,
+			};
+		}
 	}
 
 	/**

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -284,7 +284,7 @@ export class VoiceConnection extends (EventEmitter as new () => TypedEmitter<Voi
 	 */
 	public configureNetworking() {
 		const { server, state } = this.packets;
-		if (!server || !state || this.state.status === VoiceConnectionStatus.Destroyed) return;
+		if (!server || !state || this.state.status === VoiceConnectionStatus.Destroyed || !server.endpoint) return;
 
 		const networking = new Networking(
 			{

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -120,7 +120,11 @@ describe('VoiceConnection#addServerPacket', () => {
 	test('Stores the packet and attempts to configure networking', () => {
 		const { voiceConnection } = createFakeVoiceConnection();
 		voiceConnection.configureNetworking = jest.fn();
-		const dummy = Symbol('dummy') as any;
+		const dummy = {
+			endpoint: 'discord.com',
+			guild_id: 123,
+			token: 'abc',
+		} as any;
 		voiceConnection['addServerPacket'](dummy);
 		expect(voiceConnection['packets'].server).toBe(dummy);
 		expect(voiceConnection.configureNetworking).toHaveBeenCalled();
@@ -130,7 +134,11 @@ describe('VoiceConnection#addServerPacket', () => {
 		const { voiceConnection } = createFakeVoiceConnection();
 		voiceConnection['packets'].server = Symbol('old') as any;
 		voiceConnection.configureNetworking = jest.fn();
-		const dummy = Symbol('dummy') as any;
+		const dummy = {
+			endpoint: 'discord.com',
+			guild_id: 123,
+			token: 'abc',
+		} as any;
 		voiceConnection['addServerPacket'](dummy);
 		expect(voiceConnection['packets'].server).toBe(dummy);
 		expect(voiceConnection.configureNetworking).toHaveBeenCalled();

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -143,6 +143,21 @@ describe('VoiceConnection#addServerPacket', () => {
 		expect(voiceConnection['packets'].server).toBe(dummy);
 		expect(voiceConnection.configureNetworking).toHaveBeenCalled();
 	});
+
+	test('Disconnects when given a null endpoint', () => {
+		const { voiceConnection } = createFakeVoiceConnection();
+		voiceConnection['packets'].server = Symbol('old') as any;
+		voiceConnection.configureNetworking = jest.fn();
+		const dummy = {
+			endpoint: null,
+			guild_id: 123,
+			token: 'abc',
+		} as any;
+		voiceConnection['addServerPacket'](dummy);
+		expect(voiceConnection['packets'].server).toBe(dummy);
+		expect(voiceConnection.configureNetworking).not.toHaveBeenCalled();
+		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Disconnected);
+	});
 });
 
 describe('VoiceConnection#addStatePacket', () => {

--- a/src/networking/Networking.ts
+++ b/src/networking/Networking.ts
@@ -1,4 +1,4 @@
-import { VoiceOPCodes } from 'discord-api-types/v8/gateway';
+import { VoiceOPCodes } from 'discord-api-types/voice/v4';
 import { EventEmitter } from 'events';
 import { VoiceUDPSocket } from './VoiceUDPSocket';
 import { VoiceWebSocket } from './VoiceWebSocket';

--- a/src/networking/VoiceWebSocket.ts
+++ b/src/networking/VoiceWebSocket.ts
@@ -1,4 +1,4 @@
-import { VoiceOPCodes } from 'discord-api-types/v8/gateway';
+import { VoiceOPCodes } from 'discord-api-types/voice/v4';
 import EventEmitter from 'events';
 import WebSocket, { MessageEvent } from 'ws';
 import TypedEmitter from 'typed-emitter';

--- a/src/networking/__tests__/VoiceWebSocket.test.ts
+++ b/src/networking/__tests__/VoiceWebSocket.test.ts
@@ -1,4 +1,4 @@
-import { VoiceOPCodes } from 'discord-api-types/v8/gateway';
+import { VoiceOPCodes } from 'discord-api-types/voice/v4';
 import EventEmitter, { once } from 'events';
 import WS from 'jest-websocket-mock';
 import { VoiceWebSocket } from '../VoiceWebSocket';

--- a/src/receive/VoiceReceiver.ts
+++ b/src/receive/VoiceReceiver.ts
@@ -1,4 +1,4 @@
-import { VoiceOPCodes } from 'discord-api-types/v8';
+import { VoiceOPCodes } from 'discord-api-types/voice/v4';
 import { SILENCE_FRAME } from '../audio/AudioPlayer';
 import { ConnectionData, Networking, NetworkingState } from '../networking/Networking';
 import { VoiceUDPSocket } from '../networking/VoiceUDPSocket';

--- a/src/receive/__tests__/VoiceReceiver.test.ts
+++ b/src/receive/__tests__/VoiceReceiver.test.ts
@@ -4,7 +4,7 @@ import { VoiceConnection as _VoiceConnection, VoiceConnectionStatus } from '../.
 import { RTP_PACKET_DESKTOP, RTP_PACKET_CHROME, RTP_PACKET_ANDROID } from './fixtures/rtp';
 import EventEmitter, { once } from 'events';
 import { createVoiceReceiver } from '..';
-import { VoiceOPCodes } from 'discord-api-types/v8/gateway';
+import { VoiceOPCodes } from 'discord-api-types/voice/v4';
 import * as fixtures from './fixtures/states';
 
 jest.mock('../../VoiceConnection');

--- a/src/util/adapter.ts
+++ b/src/util/adapter.ts
@@ -1,7 +1,4 @@
-import {
-	GatewayVoiceServerUpdateDispatchData,
-	GatewayVoiceStateUpdateDispatchData,
-} from 'discord-api-types/v8/gateway';
+import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v8';
 
 /**
  * Methods that are provided by the @discordjs/voice library to implementations of


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #99.

Since a voice connection can now be in a disconnected state _without_ a close code, the close code has now been made optional.


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
