### PR TITLE
feat(AudioResource): add encoder property, fix type for metadata

### DIFF
--- a/examples/music-bot/src/bot.ts
+++ b/examples/music-bot/src/bot.ts
@@ -146,7 +146,7 @@ client.on('interaction', async (interaction: Interaction) => {
 			const current =
 				subscription.audioPlayer.state.status === AudioPlayerStatus.Idle
 					? `Nothing is currently playing!`
-					: `Playing **${(subscription.audioPlayer.state.resource as AudioResource<Track>).metadata!.title}**`;
+					: `Playing **${(subscription.audioPlayer.state.resource as AudioResource<Track>).metadata.title}**`;
 
 			const queue = subscription.queue
 				.slice(0, 5)

--- a/examples/music-bot/src/music/subscription.ts
+++ b/examples/music-bot/src/music/subscription.ts
@@ -61,15 +61,15 @@ export class MusicSubscription {
 			if (newState.status === AudioPlayerStatus.Idle && oldState.status !== AudioPlayerStatus.Idle) {
 				// If the Idle state is entered from a non-Idle state, it means that an audio resource has finished playing.
 				// The queue is then processed to start playing the next track, if one is available.
-				(oldState.resource as AudioResource<Track>).metadata!.onFinish();
+				(oldState.resource as AudioResource<Track>).metadata.onFinish();
 				void this.processQueue();
 			} else if (newState.status === AudioPlayerStatus.Playing) {
 				// If the Playing state has been entered, then a new track has started playback.
-				(newState.resource as AudioResource<Track>).metadata!.onStart();
+				(newState.resource as AudioResource<Track>).metadata.onStart();
 			}
 		});
 
-		this.audioPlayer.on('error', (error) => (error.resource as AudioResource<Track>).metadata!.onError(error));
+		this.audioPlayer.on('error', (error) => (error.resource as AudioResource<Track>).metadata.onError(error));
 
 		voiceConnection.subscribe(this.audioPlayer);
 	}

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -45,7 +45,7 @@ export class AudioResource<T = unknown> {
 	 * contain an FFmpeg component for arbitrary inputs, and it may contain a VolumeTransformer component
 	 * for resources with inline volume transformation enabled.
 	 */
-	public readonly edges: Edge[];
+	public readonly edges: readonly Edge[];
 
 	/**
 	 * Optional metadata that can be used to identify the resource.

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -45,7 +45,7 @@ export class AudioResource<T = unknown> {
 	 * contain an FFmpeg component for arbitrary inputs, and it may contain a VolumeTransformer component
 	 * for resources with inline volume transformation enabled.
 	 */
-	public readonly pipeline: Edge[];
+	public readonly edges: Edge[];
 
 	/**
 	 * Optional metadata that can be used to identify the resource.
@@ -79,8 +79,8 @@ export class AudioResource<T = unknown> {
 	 */
 	public started = false;
 
-	public constructor(_pipeline: Edge[], streams: Readable[], metadata: T) {
-		this.pipeline = _pipeline;
+	public constructor(edges: Edge[], streams: Readable[], metadata: T) {
+		this.edges = edges;
 		this.playStream = streams.length > 1 ? (pipeline(streams, noop) as any as Readable) : streams[0];
 		this.metadata = metadata;
 

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -79,7 +79,7 @@ export class AudioResource<T = unknown> {
 	 */
 	public started = false;
 
-	public constructor(edges: Edge[], streams: Readable[], metadata: T) {
+	public constructor(edges: readonly Edge[], streams: readonly Readable[], metadata: T) {
 		this.edges = edges;
 		this.playStream = streams.length > 1 ? (pipeline(streams, noop) as any as Readable) : streams[0];
 		this.metadata = metadata;
@@ -165,7 +165,7 @@ export function inferStreamType(stream: Readable): {
 export function createAudioResource<T>(
 	input: string | Readable,
 	options: CreateAudioResourceOptions<T> = {},
-): AudioResource<T | undefined> {
+): AudioResource<T | null> {
 	let inputType = options.inputType;
 	let needsInlineVolume = Boolean(options.inlineVolume);
 
@@ -183,10 +183,10 @@ export function createAudioResource<T>(
 	if (transformerPipeline.length === 0) {
 		if (typeof input === 'string') throw new Error(`Invalid pipeline constructed for string resource '${input}'`);
 		// No adjustments required
-		return new AudioResource([], [input], options.metadata);
+		return new AudioResource([], [input], options.metadata ?? null);
 	}
 	const streams = transformerPipeline.map((edge) => edge.transformer(input));
 	if (typeof input !== 'string') streams.unshift(input);
 
-	return new AudioResource(transformerPipeline, streams, options.metadata);
+	return new AudioResource(transformerPipeline, streams, options.metadata ?? null);
 }

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -50,7 +50,7 @@ export class AudioResource<T = unknown> {
 	/**
 	 * Optional metadata that can be used to identify the resource.
 	 */
-	public metadata?: T;
+	public metadata: T;
 
 	/**
 	 * If the resource was created with inline volume transformation enabled, then this will be a
@@ -73,7 +73,7 @@ export class AudioResource<T = unknown> {
 	 */
 	public started = false;
 
-	public constructor(pipeline: Edge[], playStream: Readable, metadata?: T, volume?: VolumeTransformer) {
+	public constructor(pipeline: Edge[], playStream: Readable, metadata: T, volume?: VolumeTransformer) {
 		this.pipeline = pipeline;
 		this.playStream = playStream;
 		this.metadata = metadata;
@@ -152,7 +152,7 @@ export function inferStreamType(stream: Readable): {
 export function createAudioResource<T>(
 	input: string | Readable,
 	options: CreateAudioResourceOptions<T> = {},
-): AudioResource<T> {
+): AudioResource<T | undefined> {
 	let inputType = options.inputType;
 	let needsInlineVolume = Boolean(options.inlineVolume);
 

--- a/src/audio/__tests__/AudioPlayer.test.ts
+++ b/src/audio/__tests__/AudioPlayer.test.ts
@@ -71,7 +71,7 @@ describe('State transitions', () => {
 
 	test('Playing resource with pausing and resuming', async () => {
 		// Call AudioResource constructor directly to avoid analysing pipeline for stream
-		const resource = await started(new AudioResource([], Readable.from(silence())));
+		const resource = await started(new AudioResource([], Readable.from(silence()), [], undefined));
 		player = createAudioPlayer();
 		expect(player.state.status).toBe(AudioPlayerStatus.Idle);
 
@@ -107,7 +107,7 @@ describe('State transitions', () => {
 	});
 
 	test('Playing to Stopping', async () => {
-		const resource = await started(new AudioResource([], Readable.from(silence())));
+		const resource = await started(new AudioResource([], Readable.from(silence()), [], undefined));
 		player = createAudioPlayer();
 
 		// stop() shouldn't do anything in Idle state
@@ -126,7 +126,7 @@ describe('State transitions', () => {
 	});
 
 	test('Buffering to Playing', async () => {
-		const resource = new AudioResource([], Readable.from(silence()));
+		const resource = new AudioResource([], Readable.from(silence()), [], undefined);
 		player = createAudioPlayer();
 
 		player.play(resource);
@@ -146,7 +146,7 @@ describe('State transitions', () => {
 				throw new Error('Voice connection should have been Signalling');
 			}
 
-			const resource = await started(new AudioResource([], Readable.from(silence())));
+			const resource = await started(new AudioResource([], Readable.from(silence()), [], undefined));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Pause } });
 			connection.subscribe(player);
 
@@ -167,7 +167,7 @@ describe('State transitions', () => {
 		});
 
 		test('NoSubscriberBehavior.Play', async () => {
-			const resource = await started(new AudioResource([], Readable.from(silence())));
+			const resource = await started(new AudioResource([], Readable.from(silence()), [], undefined));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Play } });
 
 			player.play(resource);
@@ -177,7 +177,7 @@ describe('State transitions', () => {
 		});
 
 		test('NoSubscriberBehavior.Stop', async () => {
-			const resource = await started(new AudioResource([], Readable.from(silence())));
+			const resource = await started(new AudioResource([], Readable.from(silence()), [], undefined));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Stop } });
 
 			player.play(resource);
@@ -201,7 +201,9 @@ describe('State transitions', () => {
 		};
 
 		const buffer = Buffer.from([1, 2, 4, 8]);
-		const resource = await started(new AudioResource([], Readable.from([buffer, buffer, buffer, buffer, buffer])));
+		const resource = await started(
+			new AudioResource([], Readable.from([buffer, buffer, buffer, buffer, buffer]), [], undefined),
+		);
 		player = createAudioPlayer();
 		connection.subscribe(player);
 
@@ -255,7 +257,7 @@ describe('State transitions', () => {
 			networking: null as any,
 		};
 
-		const resource = await started(new AudioResource([], Readable.from([1])));
+		const resource = await started(new AudioResource([], Readable.from([1]), [], undefined));
 		resource.playStream.read();
 		player = createAudioPlayer({ behaviors: { maxMissedFrames: 5 } });
 		connection.subscribe(player);
@@ -289,7 +291,7 @@ describe('State transitions', () => {
 	});
 
 	test('checkPlayable() transitions to Idle for unreadable stream', async () => {
-		const resource = await started(new AudioResource([], Readable.from([1])));
+		const resource = await started(new AudioResource([], Readable.from([1]), [], undefined));
 		player = createAudioPlayer();
 		player.play(resource);
 		expect(player.checkPlayable()).toBe(true);
@@ -305,7 +307,7 @@ describe('State transitions', () => {
 });
 
 test('play() throws when playing a resource that has already ended', async () => {
-	const resource = await started(new AudioResource([], Readable.from([1])));
+	const resource = await started(new AudioResource([], Readable.from([1]), [], undefined));
 	player = createAudioPlayer();
 	player.play(resource);
 	expect(player.state.status).toBe(AudioPlayerStatus.Playing);
@@ -320,7 +322,7 @@ test('play() throws when playing a resource that has already ended', async () =>
 });
 
 test('Propagates errors from streams', async () => {
-	const resource = await started(new AudioResource([], Readable.from(silence())));
+	const resource = await started(new AudioResource([], Readable.from(silence()), [], undefined));
 	player = createAudioPlayer();
 	player.play(resource);
 	expect(player.state.status).toBe(AudioPlayerStatus.Playing);

--- a/src/audio/__tests__/AudioPlayer.test.ts
+++ b/src/audio/__tests__/AudioPlayer.test.ts
@@ -71,7 +71,7 @@ describe('State transitions', () => {
 
 	test('Playing resource with pausing and resuming', async () => {
 		// Call AudioResource constructor directly to avoid analysing pipeline for stream
-		const resource = await started(new AudioResource([], [Readable.from(silence())], undefined));
+		const resource = await started(new AudioResource([], [Readable.from(silence())], null));
 		player = createAudioPlayer();
 		expect(player.state.status).toBe(AudioPlayerStatus.Idle);
 
@@ -107,7 +107,7 @@ describe('State transitions', () => {
 	});
 
 	test('Playing to Stopping', async () => {
-		const resource = await started(new AudioResource([], [Readable.from(silence())], undefined));
+		const resource = await started(new AudioResource([], [Readable.from(silence())], null));
 		player = createAudioPlayer();
 
 		// stop() shouldn't do anything in Idle state
@@ -126,7 +126,7 @@ describe('State transitions', () => {
 	});
 
 	test('Buffering to Playing', async () => {
-		const resource = new AudioResource([], [Readable.from(silence())], undefined);
+		const resource = new AudioResource([], [Readable.from(silence())], null);
 		player = createAudioPlayer();
 
 		player.play(resource);
@@ -146,7 +146,7 @@ describe('State transitions', () => {
 				throw new Error('Voice connection should have been Signalling');
 			}
 
-			const resource = await started(new AudioResource([], [Readable.from(silence())], undefined));
+			const resource = await started(new AudioResource([], [Readable.from(silence())], null));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Pause } });
 			connection.subscribe(player);
 
@@ -167,7 +167,7 @@ describe('State transitions', () => {
 		});
 
 		test('NoSubscriberBehavior.Play', async () => {
-			const resource = await started(new AudioResource([], [Readable.from(silence())], undefined));
+			const resource = await started(new AudioResource([], [Readable.from(silence())], null));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Play } });
 
 			player.play(resource);
@@ -177,7 +177,7 @@ describe('State transitions', () => {
 		});
 
 		test('NoSubscriberBehavior.Stop', async () => {
-			const resource = await started(new AudioResource([], [Readable.from(silence())], undefined));
+			const resource = await started(new AudioResource([], [Readable.from(silence())], null));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Stop } });
 
 			player.play(resource);
@@ -202,7 +202,7 @@ describe('State transitions', () => {
 
 		const buffer = Buffer.from([1, 2, 4, 8]);
 		const resource = await started(
-			new AudioResource([], [Readable.from([buffer, buffer, buffer, buffer, buffer])], undefined),
+			new AudioResource([], [Readable.from([buffer, buffer, buffer, buffer, buffer])], null),
 		);
 		player = createAudioPlayer();
 		connection.subscribe(player);
@@ -257,7 +257,7 @@ describe('State transitions', () => {
 			networking: null as any,
 		};
 
-		const resource = await started(new AudioResource([], [Readable.from([1])], undefined));
+		const resource = await started(new AudioResource([], [Readable.from([1])], null));
 		resource.playStream.read();
 		player = createAudioPlayer({ behaviors: { maxMissedFrames: 5 } });
 		connection.subscribe(player);
@@ -291,7 +291,7 @@ describe('State transitions', () => {
 	});
 
 	test('checkPlayable() transitions to Idle for unreadable stream', async () => {
-		const resource = await started(new AudioResource([], [Readable.from([1])], undefined));
+		const resource = await started(new AudioResource([], [Readable.from([1])], null));
 		player = createAudioPlayer();
 		player.play(resource);
 		expect(player.checkPlayable()).toBe(true);
@@ -307,7 +307,7 @@ describe('State transitions', () => {
 });
 
 test('play() throws when playing a resource that has already ended', async () => {
-	const resource = await started(new AudioResource([], [Readable.from([1])], undefined));
+	const resource = await started(new AudioResource([], [Readable.from([1])], null));
 	player = createAudioPlayer();
 	player.play(resource);
 	expect(player.state.status).toBe(AudioPlayerStatus.Playing);
@@ -322,7 +322,7 @@ test('play() throws when playing a resource that has already ended', async () =>
 });
 
 test('Propagates errors from streams', async () => {
-	const resource = await started(new AudioResource([], [Readable.from(silence())], undefined));
+	const resource = await started(new AudioResource([], [Readable.from(silence())], null));
 	player = createAudioPlayer();
 	player.play(resource);
 	expect(player.state.status).toBe(AudioPlayerStatus.Playing);

--- a/src/audio/__tests__/AudioPlayer.test.ts
+++ b/src/audio/__tests__/AudioPlayer.test.ts
@@ -71,7 +71,7 @@ describe('State transitions', () => {
 
 	test('Playing resource with pausing and resuming', async () => {
 		// Call AudioResource constructor directly to avoid analysing pipeline for stream
-		const resource = await started(new AudioResource([], Readable.from(silence()), [], undefined));
+		const resource = await started(new AudioResource([], [Readable.from(silence())], undefined));
 		player = createAudioPlayer();
 		expect(player.state.status).toBe(AudioPlayerStatus.Idle);
 
@@ -107,7 +107,7 @@ describe('State transitions', () => {
 	});
 
 	test('Playing to Stopping', async () => {
-		const resource = await started(new AudioResource([], Readable.from(silence()), [], undefined));
+		const resource = await started(new AudioResource([], [Readable.from(silence())], undefined));
 		player = createAudioPlayer();
 
 		// stop() shouldn't do anything in Idle state
@@ -126,7 +126,7 @@ describe('State transitions', () => {
 	});
 
 	test('Buffering to Playing', async () => {
-		const resource = new AudioResource([], Readable.from(silence()), [], undefined);
+		const resource = new AudioResource([], [Readable.from(silence())], undefined);
 		player = createAudioPlayer();
 
 		player.play(resource);
@@ -146,7 +146,7 @@ describe('State transitions', () => {
 				throw new Error('Voice connection should have been Signalling');
 			}
 
-			const resource = await started(new AudioResource([], Readable.from(silence()), [], undefined));
+			const resource = await started(new AudioResource([], [Readable.from(silence())], undefined));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Pause } });
 			connection.subscribe(player);
 
@@ -167,7 +167,7 @@ describe('State transitions', () => {
 		});
 
 		test('NoSubscriberBehavior.Play', async () => {
-			const resource = await started(new AudioResource([], Readable.from(silence()), [], undefined));
+			const resource = await started(new AudioResource([], [Readable.from(silence())], undefined));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Play } });
 
 			player.play(resource);
@@ -177,7 +177,7 @@ describe('State transitions', () => {
 		});
 
 		test('NoSubscriberBehavior.Stop', async () => {
-			const resource = await started(new AudioResource([], Readable.from(silence()), [], undefined));
+			const resource = await started(new AudioResource([], [Readable.from(silence())], undefined));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Stop } });
 
 			player.play(resource);
@@ -202,7 +202,7 @@ describe('State transitions', () => {
 
 		const buffer = Buffer.from([1, 2, 4, 8]);
 		const resource = await started(
-			new AudioResource([], Readable.from([buffer, buffer, buffer, buffer, buffer]), [], undefined),
+			new AudioResource([], [Readable.from([buffer, buffer, buffer, buffer, buffer])], undefined),
 		);
 		player = createAudioPlayer();
 		connection.subscribe(player);
@@ -257,7 +257,7 @@ describe('State transitions', () => {
 			networking: null as any,
 		};
 
-		const resource = await started(new AudioResource([], Readable.from([1]), [], undefined));
+		const resource = await started(new AudioResource([], [Readable.from([1])], undefined));
 		resource.playStream.read();
 		player = createAudioPlayer({ behaviors: { maxMissedFrames: 5 } });
 		connection.subscribe(player);
@@ -291,7 +291,7 @@ describe('State transitions', () => {
 	});
 
 	test('checkPlayable() transitions to Idle for unreadable stream', async () => {
-		const resource = await started(new AudioResource([], Readable.from([1]), [], undefined));
+		const resource = await started(new AudioResource([], [Readable.from([1])], undefined));
 		player = createAudioPlayer();
 		player.play(resource);
 		expect(player.checkPlayable()).toBe(true);
@@ -307,7 +307,7 @@ describe('State transitions', () => {
 });
 
 test('play() throws when playing a resource that has already ended', async () => {
-	const resource = await started(new AudioResource([], Readable.from([1]), [], undefined));
+	const resource = await started(new AudioResource([], [Readable.from([1])], undefined));
 	player = createAudioPlayer();
 	player.play(resource);
 	expect(player.state.status).toBe(AudioPlayerStatus.Playing);
@@ -322,7 +322,7 @@ test('play() throws when playing a resource that has already ended', async () =>
 });
 
 test('Propagates errors from streams', async () => {
-	const resource = await started(new AudioResource([], Readable.from(silence()), [], undefined));
+	const resource = await started(new AudioResource([], [Readable.from(silence())], undefined));
 	player = createAudioPlayer();
 	player.play(resource);
 	expect(player.state.status).toBe(AudioPlayerStatus.Playing);

--- a/src/audio/__tests__/AudioResource.test.ts
+++ b/src/audio/__tests__/AudioResource.test.ts
@@ -55,12 +55,14 @@ describe('createAudioResource', () => {
 		const resource = createAudioResource(new opus.Encoder(), { inlineVolume: true });
 		expect(findPipeline).toHaveBeenCalledWith(StreamType.Opus, VOLUME_CONSTRAINT);
 		expect(resource.volume).toBeInstanceOf(VolumeTransformer);
+		expect(resource.encoder).toBeInstanceOf(opus.Encoder);
 	});
 
 	test('Infers from opus.OggDemuxer', () => {
 		const resource = createAudioResource(new opus.OggDemuxer());
 		expect(findPipeline).toHaveBeenCalledWith(StreamType.Opus, NO_CONSTRAINT);
 		expect(resource.volume).toBeUndefined();
+		expect(resource.encoder).toBeUndefined();
 	});
 
 	test('Infers from opus.WebmDemuxer', () => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This adds the optional `encoder` property to an AudioResource, so you could do this for example:

```ts
resource.encoder?.setBitrate(48000);
```

Also simplifies the constructor of AudioResource, as well as fixes the metadata typings. Previously, this was an issue:

```ts
(resource as AudioResource<MyMetadata>).metadata // type of MyMetadata|undefined
```

Even though the AudioResource is given a type, metadata was incorrectly optional. This is now fixed.


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
