### PR TITLE
chore(Legal): added UNLICENSE in examples

### DIFF
--- a/examples/UNLICENSE
+++ b/examples/UNLICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
 		"dist/*"
 	],
 	"dependencies": {
-		"prism-media": "^1.2.9",
-		"ws": "^7.4.4",
-		"tiny-typed-emitter": "^2.0.3",
+		"@types/ws": "^7.4.4",
 		"discord-api-types": "^0.18.1",
-		"@types/ws": "^7.4.4"
+		"prism-media": "^1.2.9",
+		"tiny-typed-emitter": "^2.0.3",
+		"ws": "^7.4.4"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.14.3",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR sub-licenses the examples folder so they're under UNLICENSE, which makes
them public-domain, and as such, it will allow users to legally be able to use
the \[boilerplate] code without needing to attribute the library's MIT license. 

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
