### PR TITLE
fix(AudioResource): improve accuracy of function signatures

### DIFF
--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -147,6 +147,11 @@ export function inferStreamType(stream: Readable): {
 	return { streamType: StreamType.Arbitrary, hasVolume: false };
 }
 
+export function createAudioResource(
+	input: string | Readable,
+	options: Pick<CreateAudioResourceOptions<unknown>, 'inlineVolume' | 'inputType'>,
+): AudioResource<null>;
+
 /**
  * Creates an audio resource that can be played be audio players.
  *
@@ -165,7 +170,7 @@ export function inferStreamType(stream: Readable): {
 export function createAudioResource<T>(
 	input: string | Readable,
 	options: CreateAudioResourceOptions<T> = {},
-): AudioResource<T | null> {
+): AudioResource<T> {
 	let inputType = options.inputType;
 	let needsInlineVolume = Boolean(options.inlineVolume);
 
@@ -183,10 +188,10 @@ export function createAudioResource<T>(
 	if (transformerPipeline.length === 0) {
 		if (typeof input === 'string') throw new Error(`Invalid pipeline constructed for string resource '${input}'`);
 		// No adjustments required
-		return new AudioResource([], [input], options.metadata ?? null);
+		return new AudioResource<T>([], [input], (options.metadata ?? null) as any as T);
 	}
 	const streams = transformerPipeline.map((edge) => edge.transformer(input));
 	if (typeof input !== 'string') streams.unshift(input);
 
-	return new AudioResource(transformerPipeline, streams, options.metadata ?? null);
+	return new AudioResource<T>(transformerPipeline, streams, (options.metadata ?? null) as any as T);
 }

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -150,7 +150,7 @@ export function inferStreamType(stream: Readable): {
 export function createAudioResource<T>(
 	input: string | Readable,
 	options: CreateAudioResourceOptions<T> & Pick<CreateAudioResourceOptions<T>, 'metadata'>,
-): AudioResource<T>;
+): AudioResource<T extends null | undefined ? null : T>;
 
 export function createAudioResource<T extends null | undefined>(
 	input: string | Readable,

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -147,9 +147,9 @@ export function inferStreamType(stream: Readable): {
 	return { streamType: StreamType.Arbitrary, hasVolume: false };
 }
 
-export function createAudioResource(
+export function createAudioResource<T extends undefined | null>(
 	input: string | Readable,
-	options: Pick<CreateAudioResourceOptions<unknown>, 'inlineVolume' | 'inputType'>,
+	options: Omit<CreateAudioResourceOptions<T>, 'metadata'>,
 ): AudioResource<null>;
 
 /**

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -149,7 +149,11 @@ export function inferStreamType(stream: Readable): {
 
 export function createAudioResource<T>(
 	input: string | Readable,
-	options: CreateAudioResourceOptions<T> & Pick<CreateAudioResourceOptions<T>, 'metadata'>,
+	options: CreateAudioResourceOptions<T> &
+		Pick<
+			T extends null | undefined ? CreateAudioResourceOptions<T> : Required<CreateAudioResourceOptions<T>>,
+			'metadata'
+		>,
 ): AudioResource<T extends null | undefined ? null : T>;
 
 export function createAudioResource<T extends null | undefined>(

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -147,9 +147,14 @@ export function inferStreamType(stream: Readable): {
 	return { streamType: StreamType.Arbitrary, hasVolume: false };
 }
 
-export function createAudioResource<T extends undefined | null>(
+export function createAudioResource<T>(
 	input: string | Readable,
-	options: Omit<CreateAudioResourceOptions<T>, 'metadata'>,
+	options: CreateAudioResourceOptions<T> & Pick<CreateAudioResourceOptions<T>, 'metadata'>,
+): AudioResource<T>;
+
+export function createAudioResource<T extends null | undefined>(
+	input: string | Readable,
+	options?: Omit<CreateAudioResourceOptions<T>, 'metadata'>,
 ): AudioResource<null>;
 
 /**
@@ -188,10 +193,10 @@ export function createAudioResource<T>(
 	if (transformerPipeline.length === 0) {
 		if (typeof input === 'string') throw new Error(`Invalid pipeline constructed for string resource '${input}'`);
 		// No adjustments required
-		return new AudioResource<T>([], [input], (options.metadata ?? null) as any as T);
+		return new AudioResource<T>([], [input], (options.metadata ?? null) as T);
 	}
 	const streams = transformerPipeline.map((edge) => edge.transformer(input));
 	if (typeof input !== 'string') streams.unshift(input);
 
-	return new AudioResource<T>(transformerPipeline, streams, (options.metadata ?? null) as any as T);
+	return new AudioResource<T>(transformerPipeline, streams, (options.metadata ?? null) as T);
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`createAudioResource` currently has an invalid return type, this PR fixes it.


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes