### PR TITLE
feat(Util): add Opus audio probing utility

### DIFF
--- a/examples/music-bot/README.md
+++ b/examples/music-bot/README.md
@@ -11,6 +11,7 @@ If you're looking to make your own music bot that is fairly simple, this example
 ```bash
 # Clone the main repository, and then run:
 $ npm install
+$ npm run build
 
 # Open this example and install dependencies
 $ cd examples/music-bot

--- a/examples/music-bot/README.md
+++ b/examples/music-bot/README.md
@@ -9,8 +9,11 @@ If you're looking to make your own music bot that is fairly simple, this example
 ## Usage
 
 ```bash
-# Clone the main repository
+# Clone the main repository, and then run:
 $ npm install
+
+# Ensure youtube-dl is installed (see https://github.com/ytdl-org/youtube-dl#installation for all options)
+$ sudo -H pip install --upgrade youtube-dl
 
 # Open this example and install dependencies
 $ cd examples/music-bot

--- a/examples/music-bot/README.md
+++ b/examples/music-bot/README.md
@@ -12,9 +12,6 @@ If you're looking to make your own music bot that is fairly simple, this example
 # Clone the main repository, and then run:
 $ npm install
 
-# Ensure youtube-dl is installed (see https://github.com/ytdl-org/youtube-dl#installation for all options)
-$ sudo -H pip install --upgrade youtube-dl
-
 # Open this example and install dependencies
 $ cd examples/music-bot
 $ npm install

--- a/examples/music-bot/package.json
+++ b/examples/music-bot/package.json
@@ -18,6 +18,7 @@
 		"discord-api-types": "^0.18.1",
 		"discord.js": "^13.0.0-dev.02693bc02f45980d8165820a103220f0027b96b7",
 		"libsodium-wrappers": "^0.7.9",
+		"youtube-dl-exec": "^1.2.4",
 		"ytdl-core": "^4.8.2"
 	},
 	"devDependencies": {

--- a/examples/music-bot/package.json
+++ b/examples/music-bot/package.json
@@ -18,9 +18,10 @@
 		"discord-api-types": "^0.18.1",
 		"discord.js": "^13.0.0-dev.c6aeebb18d6b969f7c8bdb1b719883d4384dd03e",
 		"libsodium-wrappers": "^0.7.9",
-		"ytdl-core-discord": "^1.3.0"
+		"ytdl-core": "^4.8.2"
 	},
 	"devDependencies": {
-		"tsconfig-paths": "^3.9.0"
+		"tsconfig-paths": "^3.9.0",
+		"typescript": "4.2"
 	}
 }

--- a/examples/music-bot/package.json
+++ b/examples/music-bot/package.json
@@ -22,6 +22,6 @@
 	},
 	"devDependencies": {
 		"tsconfig-paths": "^3.9.0",
-		"typescript": "4.2"
+		"typescript": "~4.2.2"
 	}
 }

--- a/examples/music-bot/package.json
+++ b/examples/music-bot/package.json
@@ -16,7 +16,7 @@
 	"dependencies": {
 		"@discordjs/opus": "^0.5.0",
 		"discord-api-types": "^0.18.1",
-		"discord.js": "^13.0.0-dev.c6aeebb18d6b969f7c8bdb1b719883d4384dd03e",
+		"discord.js": "^13.0.0-dev.02693bc02f45980d8165820a103220f0027b96b7",
 		"libsodium-wrappers": "^0.7.9",
 		"ytdl-core": "^4.8.2"
 	},

--- a/examples/music-bot/src/music/track.ts
+++ b/examples/music-bot/src/music/track.ts
@@ -68,7 +68,7 @@ export class Track implements TrackData {
 			process
 				.once('spawn', () => {
 					demuxProbe(stream)
-						.then((probe) => resolve(createAudioResource(stream, { metadata: this, inputType: probe.type })))
+						.then((probe) => resolve(createAudioResource(probe.stream, { metadata: this, inputType: probe.type })))
 						.catch(onError);
 				})
 				.catch(onError);

--- a/examples/music-bot/src/music/track.ts
+++ b/examples/music-bot/src/music/track.ts
@@ -45,12 +45,16 @@ export class Track implements TrackData {
 	 */
 	public createAudioResource(): Promise<AudioResource<Track>> {
 		return new Promise((resolve, reject) => {
-			const process = ytdl(this.url, {
-				o: '-',
-				q: true,
-				f: 'bestaudio[ext=webm+acodec=opus+asr=48000]/bestaudio',
-				r: '100K'
-			}, { stdio: ['ignore', 'pipe', 'ignore']});
+			const process = ytdl(
+				this.url,
+				{
+					o: '-',
+					q: true,
+					f: 'bestaudio[ext=webm+acodec=opus+asr=48000]/bestaudio',
+					r: '100K',
+				},
+				{ stdio: ['ignore', 'pipe', 'ignore'] },
+			);
 			if (!process.stdout) {
 				reject(new Error('No stdout'));
 				return;
@@ -61,12 +65,12 @@ export class Track implements TrackData {
 				stream.resume();
 				reject(error);
 			};
-			process.once('spawn', () => {
+			void process.once('spawn', () => {
 				demuxProbe(stream)
-					.then((inputType) => resolve(createAudioResource(stream, { metadata: this, inputType })))
+					.then((probe) => resolve(createAudioResource(stream, { metadata: this, inputType: probe.type })))
 					.catch(onError);
 			});
-			process.once('error', onError);
+			void process.once('error', onError);
 		});
 	}
 

--- a/examples/music-bot/src/music/track.ts
+++ b/examples/music-bot/src/music/track.ts
@@ -47,7 +47,7 @@ export class Track implements TrackData {
 		return new Promise((resolve, reject) => {
 			const process = spawn(
 				'youtube-dl',
-				['-o', '-', '-q', '-f', 'bestaudio[ext=webm+acodec=opus+asr=48000]', this.url],
+				['-o', '-', '-q', '-f', 'bestaudio[ext=webm+acodec=opus+asr=48000]/bestaudio', '-r', '100K', this.url],
 				{ stdio: ['ignore', 'pipe', 'ignore'] },
 			);
 			const onError = (error: Error) => {

--- a/examples/music-bot/src/music/track.ts
+++ b/examples/music-bot/src/music/track.ts
@@ -65,12 +65,13 @@ export class Track implements TrackData {
 				stream.resume();
 				reject(error);
 			};
-			void process.once('spawn', () => {
-				demuxProbe(stream)
-					.then((probe) => resolve(createAudioResource(stream, { metadata: this, inputType: probe.type })))
-					.catch(onError);
-			});
-			void process.once('error', onError);
+			void process
+				.once('spawn', () => {
+					demuxProbe(stream)
+						.then((probe) => resolve(createAudioResource(stream, { metadata: this, inputType: probe.type })))
+						.catch(onError);
+				})
+				.once('error', onError);
 		});
 	}
 

--- a/examples/music-bot/src/music/track.ts
+++ b/examples/music-bot/src/music/track.ts
@@ -65,13 +65,13 @@ export class Track implements TrackData {
 				stream.resume();
 				reject(error);
 			};
-			void process
+			process
 				.once('spawn', () => {
 					demuxProbe(stream)
 						.then((probe) => resolve(createAudioResource(stream, { metadata: this, inputType: probe.type })))
 						.catch(onError);
 				})
-				.once('error', onError);
+				.catch(onError);
 		});
 	}
 

--- a/examples/music-bot/tsconfig.json
+++ b/examples/music-bot/tsconfig.json
@@ -6,8 +6,9 @@
 		"rootDir": "src",
 		"paths": {
 			"@discordjs/voice": ["../../"],
-			"sodium": ["./node_modules/sodium"],
 			"@discordjs/opus": ["./node_modules/@discordjs/opus"],
+			"sodium": ["./node_modules/sodium"],
+			"libsodium-wrappers": ["./node_modules/libsodium-wrappers"],
 			"tweetnacl": ["./node_modules/tweetnacl"]
 		}
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@types/ws": "^7.4.4",
 				"discord-api-types": "^0.18.1",
-				"prism-media": "^1.2.9",
+				"prism-media": "^1.3.1",
 				"tiny-typed-emitter": "^2.0.3",
 				"ws": "^7.4.4"
 			},
@@ -8940,9 +8940,9 @@
 			}
 		},
 		"node_modules/prism-media": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.2.9.tgz",
-			"integrity": "sha512-UHCYuqHipbTR1ZsXr5eg4JUmHER8Ss4YEb9Azn+9zzJ7/jlTtD1h0lc4g6tNx3eMlB8Mp6bfll0LPMAV4R6r3Q==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.1.tgz",
+			"integrity": "sha512-nyYAa3KB4qteJIqdguKmwxTJgy55xxUtkJ3uRnOvO5jO+frci+9zpRXw6QZVcfDeva3S654fU9+26P2OSTzjHw==",
 			"peerDependencies": {
 				"@discordjs/opus": "^0.5.0",
 				"ffmpeg-static": "^4.2.7 || ^3.0.0 || ^2.4.0",
@@ -17427,9 +17427,9 @@
 			}
 		},
 		"prism-media": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.2.9.tgz",
-			"integrity": "sha512-UHCYuqHipbTR1ZsXr5eg4JUmHER8Ss4YEb9Azn+9zzJ7/jlTtD1h0lc4g6tNx3eMlB8Mp6bfll0LPMAV4R6r3Q=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.1.tgz",
+			"integrity": "sha512-nyYAa3KB4qteJIqdguKmwxTJgy55xxUtkJ3uRnOvO5jO+frci+9zpRXw6QZVcfDeva3S654fU9+26P2OSTzjHw=="
 		},
 		"progress": {
 			"version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	"dependencies": {
 		"@types/ws": "^7.4.4",
 		"discord-api-types": "^0.18.1",
-		"prism-media": "^1.2.9",
+		"prism-media": "^1.3.1",
 		"tiny-typed-emitter": "^2.0.3",
 		"ws": "^7.4.4"
 	},

--- a/src/util/__tests__/demuxProbe.test.ts
+++ b/src/util/__tests__/demuxProbe.test.ts
@@ -1,0 +1,56 @@
+import { demuxProbe } from '../demuxProbe';
+import { opus as _opus } from 'prism-media';
+import { Readable } from 'stream';
+import { StreamType } from '../../audio';
+import { once } from 'events';
+
+jest.mock('prism-media');
+
+const WebDemuxer = _opus.WebmDemuxer as unknown as jest.Mock<_opus.WebmDemuxer>;
+const OggDemuxer = _opus.OggDemuxer as unknown as jest.Mock<_opus.OggDemuxer>;
+
+async function* gen() {
+	for (let i = 0; i < 10; i++) {
+		yield Buffer.from([i]);
+		await nextTick();
+	}
+}
+
+const expectedOutput = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+async function collectStream(stream: Readable): Promise<Buffer> {
+	let output = Buffer.alloc(0);
+	await once(stream, 'readable');
+	for await (const data of stream) {
+		output = Buffer.concat([output, data]);
+	}
+	return output;
+}
+
+function nextTick() {
+	return new Promise((resolve) => {
+		process.nextTick(resolve);
+	});
+}
+
+describe('demuxProbe', () => {
+	const webmWrite: jest.Mock<(buffer: Buffer) => void> = jest.fn();
+	const oggWrite: jest.Mock<(buffer: Buffer) => void> = jest.fn();
+
+	beforeAll(() => {
+		WebDemuxer.prototype.write = webmWrite;
+		OggDemuxer.prototype.write = oggWrite;
+	});
+
+	beforeEach(() => {
+		webmWrite.mockReset();
+		oggWrite.mockReset();
+	});
+
+	test('Defaults to arbitrary', async () => {
+		const stream = Readable.from(gen(), { objectMode: false });
+		const probe = await demuxProbe(stream);
+		expect(probe.type).toBe(StreamType.Arbitrary);
+		await expect(collectStream(probe.stream)).resolves.toEqual(expectedOutput);
+	});
+});

--- a/src/util/demuxProbe.ts
+++ b/src/util/demuxProbe.ts
@@ -14,8 +14,18 @@ export function validateDiscordOpusHead(opusHead: Buffer): boolean {
 	return channels === 2 && sampleRate === 48000;
 }
 
+/**
+ * The resulting information after probing an audio stream
+ */
 export interface ProbeInfo {
+	/**
+	 * The readable audio stream to use. You should use this rather than the input stream, as the probing
+	 * function can sometimes read the input stream to its end and cause the stream to close.
+	 */
 	stream: Readable;
+	/**
+	 * The recommended stream type for this audio stream
+	 */
 	type: StreamType;
 }
 

--- a/src/util/demuxProbe.ts
+++ b/src/util/demuxProbe.ts
@@ -3,7 +3,12 @@ import { opus } from 'prism-media';
 import { noop } from './util';
 import { StreamType } from '..';
 
-export function discordOpusHeadValidator(opusHead: Buffer): boolean {
+/**
+ * Takes an Opus Head, and verifies whether the associated Opus audio is suitable to play in a Discord voice channel.
+ * @param opusHead The Opus Head to validate
+ * @returns true if suitable to play in a Discord voice channel, false otherwise
+ */
+export function validateDiscordOpusHead(opusHead: Buffer): boolean {
 	const channels = opusHead.readUInt8(9);
 	const sampleRate = opusHead.readUInt32LE(12);
 	return channels === 2 && sampleRate === 48000;
@@ -19,7 +24,7 @@ export function discordOpusHeadValidator(opusHead: Buffer): boolean {
 export function demuxProbe(
 	stream: Readable,
 	probeSize = 1024,
-	validator = discordOpusHeadValidator,
+	validator = validateDiscordOpusHead,
 ): Promise<StreamType> {
 	return new Promise((resolve, reject) => {
 		// Preconditions

--- a/src/util/demuxProbe.ts
+++ b/src/util/demuxProbe.ts
@@ -95,9 +95,9 @@ export function demuxProbe(
 			}
 		};
 
+		stream.once('error', reject);
 		stream.on('data', onData);
 		stream.once('close', onClose);
 		stream.once('end', onClose);
-		stream.once('error', reject);
 	});
 }

--- a/src/util/demuxProbe.ts
+++ b/src/util/demuxProbe.ts
@@ -77,6 +77,5 @@ export function demuxProbe(
 		stream.once('close', onClose);
 		stream.once('end', onClose);
 		stream.once('error', reject);
-		stream.on('error', console.log);
 	});
 }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,3 +1,4 @@
 export * from './generateDependencyReport';
 export * from './entersState';
 export * from './adapter';
+export * from './demuxProbe';

--- a/src/util/opusDemuxProbe.ts
+++ b/src/util/opusDemuxProbe.ts
@@ -1,0 +1,90 @@
+import { PassThrough, pipeline, Readable } from 'stream';
+import { opus } from 'prism-media';
+import { noop } from './util';
+import { StreamType } from '..';
+
+export function discordOpusHeadValidator(opusHead: Buffer): boolean {
+	const channels = opusHead.readUInt8(9);
+	const sampleRate = opusHead.readUInt32LE(12);
+	return channels === 2 && sampleRate === 48000;
+}
+
+export interface ProbeResult {
+	stream: Readable;
+	type: StreamType;
+}
+
+/**
+ * Attempt to probe a readable stream to figure out whether it can be demuxed using an Ogg or WebM Opus demuxer.
+ * @param stream The readable stream to probe
+ * @param probeSize The number of bytes to attempt to read before giving up on the probe
+ * @param validator The Opus Head validator function
+ * @experimental
+ */
+export function opusDemuxProbe(
+	stream: Readable,
+	probeSize = 1024,
+	validator = discordOpusHeadValidator,
+): Promise<ProbeResult> {
+	return new Promise((resolve, reject) => {
+		// Preconditions
+		if (stream.readableObjectMode) reject(new Error('Cannot probe a readable stream in object mode'));
+		if (stream.readableEnded) reject(new Error('Cannot probe a stream that has ended'));
+
+		let readBuffer = Buffer.alloc(0);
+
+		let resolved: StreamType | undefined = undefined;
+
+		const finish = (type: StreamType) => {
+			stream.off('data', onData);
+			stream.off('close', onClose);
+			stream.off('end', onClose);
+			stream.pause();
+			const output = new PassThrough();
+			resolved = type;
+			resolve({
+				stream: pipeline([stream, output], noop) as any as Readable,
+				type,
+			});
+			stream.push(readBuffer);
+		};
+
+		const foundHead = (type: StreamType) => (head: Buffer) => {
+			if (validator(head)) {
+				finish(type);
+			}
+		};
+
+		const webm = new opus.WebmDemuxer();
+		webm.once('error', noop);
+		webm.on('head', foundHead(StreamType.WebmOpus));
+
+		const ogg = new opus.OggDemuxer();
+		ogg.once('error', noop);
+		ogg.on('head', foundHead(StreamType.OggOpus));
+
+		const onClose = () => {
+			if (!resolved) {
+				finish(StreamType.Arbitrary);
+			}
+		};
+
+		const onData = (buffer: Buffer) => {
+			readBuffer = Buffer.concat([readBuffer, buffer]);
+
+			webm.write(buffer);
+			ogg.write(buffer);
+
+			if (readBuffer.length >= probeSize) {
+				stream.off('data', onData);
+				stream.pause();
+				process.nextTick(onClose);
+			}
+		};
+
+		stream.on('data', onData);
+		stream.once('close', onClose);
+		stream.once('end', onClose);
+		stream.once('error', reject);
+	});
+}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This adds an Opus audio probing utility that will help with deciding the best way to handle an audio stream. It can determine whether the input stream is a valid WebM or Ogg Opus stream for playing in Discord voice channels (i.e. an Opus stream at 48kHz sample rate and 2 audio channels). This allows you to demux the stream, rather than blindly passing it to FFmpeg, for improved performance. For example:

```ts
import { createReadStream } from 'fs';
import { StreamType, demuxProbe, createAudioResource } from '@discordjs/voice';

async function start() {
  // Example verifications
  assert.equal(await demuxProbe(createReadStream('file.mp3')), StreamType.Arbitrary);
  assert.equal(await demuxProbe(createReadStream('file.opus')), StreamType.OggOpus);
  assert.equal(await demuxProbe(createReadStream('file.webm')), StreamType.WebmOpus);

  // Example of creating an audio resource using the probe
  const stream = createReadStream('./song.unknownextension');
  createAudioResource(stream, { inputType: await demuxProbe(stream) });
}
```

The motivation for this PR was that a lot of users were having issues with `ytdl-core` abort errors, e.g. see #116. The `demuxProbe` util allows us to use `youtube-dl` instead without sacrificing the same performance benefits. The music bot example has been updated to reflect this.

To-do:
- [x] Tests

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)