### PR TITLE
feat!: add silence padding frames to AudioResources

### DIFF
--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -454,7 +454,7 @@ export class AudioPlayer extends TypedEmitter<AudioPlayerEvents> {
 		if (state.status === AudioPlayerStatus.Idle || state.status === AudioPlayerStatus.Buffering) return false;
 
 		// If the stream has been destroyed or is no longer readable, then transition to the Idle state.
-		if (!state.resource.playStream.readable) {
+		if (!state.resource.readable) {
 			this.state = {
 				status: AudioPlayerStatus.Idle,
 			};

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -321,7 +321,7 @@ export class AudioPlayer extends TypedEmitter<AudioPlayerEvents> {
 	 * @throws Will throw if attempting to play an audio resource that has already ended, or is being played by another player.
 	 */
 	public play<T>(resource: AudioResource<T>) {
-		if (resource.playStream.readableEnded || resource.playStream.destroyed) {
+		if (resource.ended) {
 			throw new Error('Cannot play a resource that has already ended.');
 		}
 

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -132,7 +132,7 @@ export class AudioResource<T = unknown> {
 	 * Whether this resource has ended or not.
 	 */
 	public get ended() {
-		return this.playStream.readableEnded || this.playStream.destroyed;
+		return this.playStream.readableEnded || this.playStream.destroyed || this.silenceRemaining === 0;
 	}
 
 	/**

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -97,6 +97,10 @@ export class AudioResource<T = unknown> {
 			.catch(noop);
 	}
 
+	public get ended() {
+		return this.playStream.readableEnded || this.playStream.destroyed;
+	}
+
 	/**
 	 * Attempts to read an Opus packet from the audio resource. If a packet is available, the playbackDuration
 	 * is incremented.

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -145,7 +145,9 @@ export class AudioResource<T = unknown> {
 	 * read from it.
 	 */
 	public read(): Buffer | null {
-		if (this.silenceRemaining > 0) {
+		if (this.silenceRemaining === 0) {
+			return null;
+		} else if (this.silenceRemaining > 0) {
 			this.silenceRemaining--;
 			return SILENCE_FRAME;
 		}

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -119,6 +119,7 @@ export class AudioResource<T = unknown> {
 	 * while there are silence padding frames left to play.
 	 */
 	public get readable() {
+		if (this.silenceRemaining === 0) return false;
 		const real = this.playStream.readable;
 		if (!real) {
 			if (this.silenceRemaining === -1) this.silenceRemaining = this.silencePaddingFrames;

--- a/src/audio/__tests__/AudioPlayer.test.ts
+++ b/src/audio/__tests__/AudioPlayer.test.ts
@@ -58,7 +58,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	player?.stop();
+	player?.stop(true);
 });
 
 describe('State transitions', () => {
@@ -111,7 +111,7 @@ describe('State transitions', () => {
 		player = createAudioPlayer();
 
 		// stop() shouldn't do anything in Idle state
-		expect(player.stop()).toBe(false);
+		expect(player.stop(true)).toBe(false);
 		expect(player.state.status).toBe(AudioPlayerStatus.Idle);
 
 		player.play(resource);
@@ -119,7 +119,7 @@ describe('State transitions', () => {
 		expect(addAudioPlayerMock).toBeCalledTimes(1);
 		expect(deleteAudioPlayerMock).toBeCalledTimes(0);
 
-		expect(player.stop()).toBe(true);
+		expect(player.stop(true)).toBe(true);
 		expect(player.state.status).toBe(AudioPlayerStatus.Idle);
 		expect(addAudioPlayerMock).toBeCalledTimes(1);
 		expect(deleteAudioPlayerMock).toBeCalledTimes(1);
@@ -239,7 +239,7 @@ describe('State transitions', () => {
 		expect(prepareAudioPacket).toHaveBeenCalledTimes(6);
 		expect(prepareAudioPacket.mock.calls[5][0]).toEqual(silence().next().value);
 
-		player.stop();
+		player.stop(true);
 		expect(player.state.status).toBe(AudioPlayerStatus.Idle);
 		expect(connection.setSpeaking).toBeCalledTimes(1);
 		expect(connection.setSpeaking).toHaveBeenLastCalledWith(false);
@@ -257,7 +257,7 @@ describe('State transitions', () => {
 			networking: null as any,
 		};
 
-		const resource = await started(new AudioResource([], [Readable.from([1])], null, 5));
+		const resource = await started(new AudioResource([], [Readable.from([1])], null, 0));
 		resource.playStream.read();
 		player = createAudioPlayer({ behaviors: { maxMissedFrames: 5 } });
 		connection.subscribe(player);
@@ -316,7 +316,7 @@ test('play() throws when playing a resource that has already ended', async () =>
 		await wait();
 	}
 	expect(resource.playStream.readableEnded).toBe(true);
-	player.stop();
+	player.stop(true);
 	expect(player.state.status).toBe(AudioPlayerStatus.Idle);
 	expect(() => player.play(resource)).toThrow();
 });

--- a/src/audio/__tests__/AudioPlayer.test.ts
+++ b/src/audio/__tests__/AudioPlayer.test.ts
@@ -71,7 +71,7 @@ describe('State transitions', () => {
 
 	test('Playing resource with pausing and resuming', async () => {
 		// Call AudioResource constructor directly to avoid analysing pipeline for stream
-		const resource = await started(new AudioResource([], [Readable.from(silence())], null));
+		const resource = await started(new AudioResource([], [Readable.from(silence())], null, 5));
 		player = createAudioPlayer();
 		expect(player.state.status).toBe(AudioPlayerStatus.Idle);
 
@@ -107,7 +107,7 @@ describe('State transitions', () => {
 	});
 
 	test('Playing to Stopping', async () => {
-		const resource = await started(new AudioResource([], [Readable.from(silence())], null));
+		const resource = await started(new AudioResource([], [Readable.from(silence())], null, 5));
 		player = createAudioPlayer();
 
 		// stop() shouldn't do anything in Idle state
@@ -126,7 +126,7 @@ describe('State transitions', () => {
 	});
 
 	test('Buffering to Playing', async () => {
-		const resource = new AudioResource([], [Readable.from(silence())], null);
+		const resource = new AudioResource([], [Readable.from(silence())], null, 5);
 		player = createAudioPlayer();
 
 		player.play(resource);
@@ -146,7 +146,7 @@ describe('State transitions', () => {
 				throw new Error('Voice connection should have been Signalling');
 			}
 
-			const resource = await started(new AudioResource([], [Readable.from(silence())], null));
+			const resource = await started(new AudioResource([], [Readable.from(silence())], null, 5));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Pause } });
 			connection.subscribe(player);
 
@@ -167,7 +167,7 @@ describe('State transitions', () => {
 		});
 
 		test('NoSubscriberBehavior.Play', async () => {
-			const resource = await started(new AudioResource([], [Readable.from(silence())], null));
+			const resource = await started(new AudioResource([], [Readable.from(silence())], null, 5));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Play } });
 
 			player.play(resource);
@@ -177,7 +177,7 @@ describe('State transitions', () => {
 		});
 
 		test('NoSubscriberBehavior.Stop', async () => {
-			const resource = await started(new AudioResource([], [Readable.from(silence())], null));
+			const resource = await started(new AudioResource([], [Readable.from(silence())], null, 5));
 			player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Stop } });
 
 			player.play(resource);
@@ -202,7 +202,7 @@ describe('State transitions', () => {
 
 		const buffer = Buffer.from([1, 2, 4, 8]);
 		const resource = await started(
-			new AudioResource([], [Readable.from([buffer, buffer, buffer, buffer, buffer])], null),
+			new AudioResource([], [Readable.from([buffer, buffer, buffer, buffer, buffer])], null, 5),
 		);
 		player = createAudioPlayer();
 		connection.subscribe(player);
@@ -257,7 +257,7 @@ describe('State transitions', () => {
 			networking: null as any,
 		};
 
-		const resource = await started(new AudioResource([], [Readable.from([1])], null));
+		const resource = await started(new AudioResource([], [Readable.from([1])], null, 5));
 		resource.playStream.read();
 		player = createAudioPlayer({ behaviors: { maxMissedFrames: 5 } });
 		connection.subscribe(player);
@@ -291,7 +291,7 @@ describe('State transitions', () => {
 	});
 
 	test('checkPlayable() transitions to Idle for unreadable stream', async () => {
-		const resource = await started(new AudioResource([], [Readable.from([1])], null));
+		const resource = await started(new AudioResource([], [Readable.from([1])], null, 0));
 		player = createAudioPlayer();
 		player.play(resource);
 		expect(player.checkPlayable()).toBe(true);
@@ -307,7 +307,7 @@ describe('State transitions', () => {
 });
 
 test('play() throws when playing a resource that has already ended', async () => {
-	const resource = await started(new AudioResource([], [Readable.from([1])], null));
+	const resource = await started(new AudioResource([], [Readable.from([1])], null, 5));
 	player = createAudioPlayer();
 	player.play(resource);
 	expect(player.state.status).toBe(AudioPlayerStatus.Playing);
@@ -322,7 +322,7 @@ test('play() throws when playing a resource that has already ended', async () =>
 });
 
 test('Propagates errors from streams', async () => {
-	const resource = await started(new AudioResource([], [Readable.from(silence())], null));
+	const resource = await started(new AudioResource([], [Readable.from(silence())], null, 5));
 	player = createAudioPlayer();
 	player.play(resource);
 	expect(player.state.status).toBe(AudioPlayerStatus.Playing);

--- a/src/audio/__tests__/AudioResource.test.ts
+++ b/src/audio/__tests__/AudioResource.test.ts
@@ -117,5 +117,6 @@ describe('createAudioResource', () => {
 		}
 		await wait();
 		expect(resource.readable).toBe(false);
+		expect(resource.read()).toBe(null);
 	});
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #119.

By default, resources will now output 5 silence frames after their underlying stream has finished. This means that playing two resources one after the other will give a 100ms delay between both, but will prevent interpolation glitches.

This can be configured:

```ts
createAudioResource(stream, { silencePaddingFrames: 0 }); // disable this feature
createAudioResource(stream, { silencePaddingFrames: 5 }); // default
createAudioResource(stream, { silencePaddingFrames: 10 }); // 200ms worth of silence after resource finishes
```

This is mostly transparent to the AudioPlayer, except for the `#stop()` method. This method will now, by default, cause the player's resource to start outputting its final silence frames before ending - this means the AudioPlayer will not immediately enter the Idle state, it will do so after these silence frames have finished playing. This can be configured with the force parameter (defaults to false):

```ts
// ignore resource's silence padding - stop immediately and enter Idle state
player.stop(true);

// if the resource has silence padding, allow that padding to play before entering the Idle state
player.stop();
player.stop(false);
```

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)