### PR TITLE
feat: allow awaitable void event listeners, fix VoiceConnection disconnected states

### DIFF
--- a/examples/music-bot/src/music/subscription.ts
+++ b/examples/music-bot/src/music/subscription.ts
@@ -5,9 +5,14 @@ import {
 	createAudioPlayer,
 	entersState,
 	VoiceConnection,
+	VoiceConnectionDisconnectReason,
 	VoiceConnectionStatus,
 } from '@discordjs/voice';
 import { Track } from './track';
+
+function wait(time: number) {
+	return new Promise((resolve) => setTimeout(resolve, time).unref());
+}
 
 /**
  * A MusicSubscription exists for each active VoiceConnection. Each subscription has its own audio player and queue,
@@ -18,41 +23,66 @@ export class MusicSubscription {
 	public readonly audioPlayer: AudioPlayer;
 	public queue: Track[];
 	public queueLock = false;
-	public connectPromise?: Promise<void>;
+	public readyLock = false;
 
 	public constructor(voiceConnection: VoiceConnection) {
 		this.voiceConnection = voiceConnection;
 		this.audioPlayer = createAudioPlayer();
 		this.queue = [];
 
-		// Configure voice connection
-		this.voiceConnection.on('stateChange', (_, newState) => {
+		this.voiceConnection.on('stateChange', async (_, newState) => {
 			if (newState.status === VoiceConnectionStatus.Disconnected) {
-				// In the Disconnected state, try to reconnect or destroy if too many failed attempts
-				if (this.voiceConnection.reconnectAttempts < 5) {
-					setTimeout(() => {
-						if (this.voiceConnection.state.status === VoiceConnectionStatus.Disconnected) {
-							this.voiceConnection.reconnect();
-						}
-					}, (this.voiceConnection.reconnectAttempts + 1) * 5_000).unref();
+				if (newState.reason === VoiceConnectionDisconnectReason.WebSocketClose && newState.closeCode === 4014) {
+					/*
+						If the WebSocket closed with a 4014 code, this means that we should not manually attempt to reconnect,
+						but there is a chance the connection will recover itself if the reason of the disconnect was due to
+						switching voice channels. This is also the same code for the bot being kicked from the voice channel,
+						so we allow 5 seconds to figure out which scenario it is. If the bot has been kicked, we should destroy
+						the voice connection.
+					*/
+					try {
+						await entersState(this.voiceConnection, VoiceConnectionStatus.Connecting, 5_000);
+						// Probably moved voice channel
+					} catch {
+						this.voiceConnection.destroy();
+						// Probably removed from voice channel
+					}
+				} else if (this.voiceConnection.reconnectAttempts < 5) {
+					/*
+						The disconnect in this case is recoverable, and we also have <5 repeated attempts so we will reconnect.
+					*/
+					await wait((this.voiceConnection.reconnectAttempts + 1) * 5_000);
+					if (this.voiceConnection.state.status === VoiceConnectionStatus.Disconnected) {
+						this.voiceConnection.reconnect();
+					}
 				} else {
+					/*
+						The disconnect in this case may be recoverable, but we have no more remaining attempts - destroy.
+					*/
 					this.voiceConnection.destroy();
 				}
 			} else if (newState.status === VoiceConnectionStatus.Destroyed) {
-				// In the Destroyed state, stop the player and kill the queue
+				/*
+					Once destroyed, stop the subscription
+				*/
 				this.stop();
 			} else if (
-				!this.connectPromise &&
+				!this.readyLock &&
 				(newState.status === VoiceConnectionStatus.Connecting || newState.status === VoiceConnectionStatus.Signalling)
 			) {
-				// In the Signalling or Connecting states, set a time limit to prevent starvation
-				// These states can be entered after Ready in an automatic reconnect, e.g. unknown close code, UDP keep-alive failed
-				this.connectPromise = entersState(this.voiceConnection, VoiceConnectionStatus.Ready, 20_000)
-					.then(() => undefined)
-					.catch(() => {
-						if (this.voiceConnection.state.status !== VoiceConnectionStatus.Destroyed) this.voiceConnection.destroy();
-					})
-					.finally(() => (this.connectPromise = undefined));
+				/*
+					In the Signalling or Connecting states, we set a 20 second time limit for the connection to become ready
+					before destroying the voice connection. This stops the voice connection permanently existing in one of these
+					states.
+				*/
+				this.readyLock = true;
+				try {
+					await entersState(this.voiceConnection, VoiceConnectionStatus.Ready, 20_000);
+				} catch {
+					if (this.voiceConnection.state.status !== VoiceConnectionStatus.Destroyed) this.voiceConnection.destroy();
+				} finally {
+					this.readyLock = false;
+				}
 			}
 		});
 
@@ -90,7 +120,7 @@ export class MusicSubscription {
 	public stop() {
 		this.queueLock = true;
 		this.queue = [];
-		this.audioPlayer.stop();
+		this.audioPlayer.stop(true);
 	}
 
 	/**

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -11,7 +11,7 @@ import {
 } from './DataStore';
 import { DiscordGatewayAdapterImplementerMethods } from './util/adapter';
 import { Networking, NetworkingState, NetworkingStatusCode } from './networking/Networking';
-import { noop } from './util/util';
+import { Awaited, noop } from './util/util';
 import { TypedEmitter } from 'tiny-typed-emitter';
 
 /**
@@ -74,9 +74,16 @@ export enum VoiceConnectionDisconnectReason {
  */
 export interface VoiceConnectionDisconnectedBaseState {
 	status: VoiceConnectionStatus.Disconnected;
-	reason: VoiceConnectionDisconnectReason;
 	subscription?: PlayerSubscription;
 	adapter: DiscordGatewayAdapterImplementerMethods;
+}
+
+/**
+ * The state that a VoiceConnection will be in when it is not connected to a Discord voice server nor is
+ * it attempting to connect. You can manually attempt to reconnect using VoiceConnection#reconnect.
+ */
+export interface VoiceConnectionDisconnectedOtherState extends VoiceConnectionDisconnectedBaseState {
+	reason: Exclude<VoiceConnectionDisconnectReason, VoiceConnectionDisconnectReason.WebSocketClose>;
 }
 
 /**
@@ -96,7 +103,7 @@ export interface VoiceConnectionDisconnectedWebSocketState extends VoiceConnecti
  * it attempting to connect. You can manually attempt to connect using VoiceConnection#reconnect.
  */
 export type VoiceConnectionDisconnectedState =
-	| VoiceConnectionDisconnectedBaseState
+	| VoiceConnectionDisconnectedOtherState
 	| VoiceConnectionDisconnectedWebSocketState;
 
 /**
@@ -141,11 +148,11 @@ export type VoiceConnectionState =
 	| VoiceConnectionDestroyedState;
 
 export type VoiceConnectionEvents = {
-	error: (error: Error) => void;
-	debug: (message: string) => void;
-	stateChange: (oldState: VoiceConnectionState, newState: VoiceConnectionState) => void;
+	error: (error: Error) => Awaited<void>;
+	debug: (message: string) => Awaited<void>;
+	stateChange: (oldState: VoiceConnectionState, newState: VoiceConnectionState) => Awaited<void>;
 } & {
-	[status in VoiceConnectionStatus]: (oldState: VoiceConnectionState, newState: VoiceConnectionState) => void;
+	[status in VoiceConnectionStatus]: (oldState: VoiceConnectionState, newState: VoiceConnectionState) => Awaited<void>;
 };
 
 /**

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -1,5 +1,5 @@
 import { addAudioPlayer, deleteAudioPlayer } from '../DataStore';
-import { noop } from '../util/util';
+import { Awaited, noop } from '../util/util';
 import { VoiceConnection, VoiceConnectionStatus } from '../VoiceConnection';
 import { AudioPlayerError } from './AudioPlayerError';
 import { AudioResource } from './AudioResource';
@@ -139,13 +139,13 @@ export type AudioPlayerState =
 	| AudioPlayerPausedState;
 
 export type AudioPlayerEvents = {
-	error: (error: AudioPlayerError) => void;
-	debug: (message: string) => void;
-	stateChange: (oldState: AudioPlayerState, newState: AudioPlayerState) => void;
-	subscribe: (subscription: PlayerSubscription) => void;
-	unsubscribe: (subscription: PlayerSubscription) => void;
+	error: (error: AudioPlayerError) => Awaited<void>;
+	debug: (message: string) => Awaited<void>;
+	stateChange: (oldState: AudioPlayerState, newState: AudioPlayerState) => Awaited<void>;
+	subscribe: (subscription: PlayerSubscription) => Awaited<void>;
+	unsubscribe: (subscription: PlayerSubscription) => Awaited<void>;
 } & {
-	[status in AudioPlayerStatus]: (oldState: AudioPlayerState, newState: AudioPlayerState) => void;
+	[status in AudioPlayerStatus]: (oldState: AudioPlayerState, newState: AudioPlayerState) => Awaited<void>;
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
 	VoiceConnectionDestroyedState,
 	VoiceConnectionDisconnectedState,
 	VoiceConnectionDisconnectedBaseState,
+	VoiceConnectionDisconnectedOtherState,
 	VoiceConnectionDisconnectedWebSocketState,
 	VoiceConnectionDisconnectReason,
 	VoiceConnectionReadyState,

--- a/src/networking/Networking.ts
+++ b/src/networking/Networking.ts
@@ -2,7 +2,7 @@ import { VoiceOPCodes } from 'discord-api-types/voice/v4';
 import { VoiceUDPSocket } from './VoiceUDPSocket';
 import { VoiceWebSocket } from './VoiceWebSocket';
 import * as secretbox from '../util/Secretbox';
-import { noop } from '../util/util';
+import { Awaited, noop } from '../util/util';
 import { CloseEvent } from 'ws';
 import { TypedEmitter } from 'tiny-typed-emitter';
 
@@ -151,10 +151,10 @@ export interface ConnectionData {
 const nonce = Buffer.alloc(24);
 
 export interface NetworkingEvents {
-	debug: (message: string) => void;
-	error: (error: Error) => void;
-	stateChange: (oldState: NetworkingState, newState: NetworkingState) => void;
-	close: (code: number) => void;
+	debug: (message: string) => Awaited<void>;
+	error: (error: Error) => Awaited<void>;
+	stateChange: (oldState: NetworkingState, newState: NetworkingState) => Awaited<void>;
+	close: (code: number) => Awaited<void>;
 }
 
 /**

--- a/src/networking/VoiceUDPSocket.ts
+++ b/src/networking/VoiceUDPSocket.ts
@@ -1,6 +1,7 @@
 import { createSocket, Socket } from 'dgram';
 import { isIPv4 } from 'net';
 import { TypedEmitter } from 'tiny-typed-emitter';
+import { Awaited } from '../util/util';
 
 /**
  * Stores an IP address and port. Used to store socket details for the local client as well as
@@ -17,10 +18,10 @@ interface KeepAlive {
 }
 
 export interface VoiceUDPSocketEvents {
-	error: (error: Error) => void;
-	close: () => void;
-	debug: (message: string) => void;
-	message: (message: Buffer) => void;
+	error: (error: Error) => Awaited<void>;
+	close: () => Awaited<void>;
+	debug: (message: string) => Awaited<void>;
+	message: (message: Buffer) => Awaited<void>;
 }
 
 /**

--- a/src/networking/VoiceWebSocket.ts
+++ b/src/networking/VoiceWebSocket.ts
@@ -1,6 +1,7 @@
 import { VoiceOPCodes } from 'discord-api-types/voice/v4';
 import WebSocket, { MessageEvent } from 'ws';
 import { TypedEmitter } from 'tiny-typed-emitter';
+import { Awaited } from '../util/util';
 
 /**
  * Debug event for VoiceWebSocket.
@@ -10,11 +11,11 @@ import { TypedEmitter } from 'tiny-typed-emitter';
  */
 
 export interface VoiceWebSocketEvents {
-	error: (error: Error) => void;
-	open: (event: WebSocket.OpenEvent) => void;
-	close: (event: WebSocket.CloseEvent) => void;
-	debug: (message: string) => void;
-	packet: (packet: any) => void;
+	error: (error: Error) => Awaited<void>;
+	open: (event: WebSocket.OpenEvent) => Awaited<void>;
+	close: (event: WebSocket.CloseEvent) => Awaited<void>;
+	debug: (message: string) => Awaited<void>;
+	packet: (packet: any) => Awaited<void>;
 }
 
 /**

--- a/src/receive/SSRCMap.ts
+++ b/src/receive/SSRCMap.ts
@@ -1,4 +1,5 @@
 import { TypedEmitter } from 'tiny-typed-emitter';
+import { Awaited } from '../util/util';
 
 /**
  * The known data for a user in a Discord voice connection
@@ -23,8 +24,8 @@ export interface VoiceUserData {
  * The events that an SSRCMap may emit.
  */
 export interface SSRCMapEvents {
-	update: (oldData: VoiceUserData | undefined, newData: VoiceUserData) => void;
-	delete: (deletedData: VoiceUserData) => void;
+	update: (oldData: VoiceUserData | undefined, newData: VoiceUserData) => Awaited<void>;
+	delete: (deletedData: VoiceUserData) => Awaited<void>;
 }
 
 /**

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,2 +1,4 @@
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export const noop = () => {};
+
+export type Awaited<T> = T | Promise<T>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Separates two distinct VoiceConnection disconnected states so they no longer overlap.
- EventEmitters now take event handlers of type `Awaited<void>` (borrowed from @kyranet's implementation in discord.js)
- Music bot example's reconnection logic has been fixed. For some reason I ignored the advice I gave in [the voice guide](https://deploy-preview-595--discordjs-guide.netlify.app/voice/voice-connections.html#handling-disconnects) 😅

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)