### PR TITLE
feat!(VoiceConnection): add disconnect and rename reconnect to rejoin

### DIFF
--- a/examples/music-bot/src/music/subscription.ts
+++ b/examples/music-bot/src/music/subscription.ts
@@ -47,11 +47,11 @@ export class MusicSubscription {
 						this.voiceConnection.destroy();
 						// Probably removed from voice channel
 					}
-				} else if (this.voiceConnection.reconnectAttempts < 5) {
+				} else if (this.voiceConnection.rejoinAttempts < 5) {
 					/*
 						The disconnect in this case is recoverable, and we also have <5 repeated attempts so we will reconnect.
 					*/
-					await wait((this.voiceConnection.reconnectAttempts + 1) * 5_000);
+					await wait((this.voiceConnection.rejoinAttempts + 1) * 5_000);
 					this.voiceConnection.rejoin();
 				} else {
 					/*

--- a/examples/music-bot/src/music/subscription.ts
+++ b/examples/music-bot/src/music/subscription.ts
@@ -52,7 +52,7 @@ export class MusicSubscription {
 						The disconnect in this case is recoverable, and we also have <5 repeated attempts so we will reconnect.
 					*/
 					await wait((this.voiceConnection.reconnectAttempts + 1) * 5_000);
-					this.voiceConnection.reconnect();
+					this.voiceConnection.rejoin();
 				} else {
 					/*
 						The disconnect in this case may be recoverable, but we have no more remaining attempts - destroy.

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -514,7 +514,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 	}
 
 	/**
-	 * Attempts to reconnect the VoiceConnection if it is in the Disconnected state.
+	 * Attempts to rejoin (better explanation soon:tm:)
 	 *
 	 * @remarks
 	 * Calling this method successfully will automatically increment the `reconnectAttempts` counter,
@@ -524,7 +524,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 	 * A state transition from Disconnected to Signalling will be observed when this is called.
 	 */
 	public rejoin(joinConfig?: Omit<JoinConfig, 'guildId'>) {
-		if (this.state.status !== VoiceConnectionStatus.Disconnected) {
+		if (this.state.status === VoiceConnectionStatus.Destroyed) {
 			return false;
 		}
 

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -523,7 +523,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 	 *
 	 * A state transition from Disconnected to Signalling will be observed when this is called.
 	 */
-	public reconnect() {
+	public rejoin() {
 		if (this.state.status !== VoiceConnectionStatus.Disconnected) {
 			return false;
 		}

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -530,21 +530,21 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 
 		this.rejoinAttempts++;
 		Object.assign(this.joinConfig, joinConfig);
-		if (!this.state.adapter.sendPayload(createJoinVoiceChannelPayload(this.joinConfig))) {
+		if (this.state.adapter.sendPayload(createJoinVoiceChannelPayload(this.joinConfig))) {
 			this.state = {
-				adapter: this.state.adapter,
-				subscription: this.state.subscription,
-				status: VoiceConnectionStatus.Disconnected,
-				reason: VoiceConnectionDisconnectReason.AdapterUnavailable,
+				...this.state,
+				status: VoiceConnectionStatus.Signalling,
 			};
-			return false;
+			return true;
 		}
 
 		this.state = {
-			...this.state,
-			status: VoiceConnectionStatus.Signalling,
+			adapter: this.state.adapter,
+			subscription: this.state.subscription,
+			status: VoiceConnectionStatus.Disconnected,
+			reason: VoiceConnectionDisconnectReason.AdapterUnavailable,
 		};
-		return true;
+		return false;
 	}
 
 	/**

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -499,8 +499,10 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 		this.reconnectAttempts++;
 		if (!this.state.adapter.sendPayload(createJoinVoiceChannelPayload(this.joinConfig))) {
 			this.state = {
-				...this.state,
+				adapter: this.state.adapter,
+				subscription: this.state.subscription,
 				status: VoiceConnectionStatus.Disconnected,
+				reason: VoiceConnectionDisconnectReason.AdapterUnavailable,
 			};
 			return false;
 		}

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -164,10 +164,10 @@ export type VoiceConnectionEvents = {
  */
 export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 	/**
-	 * The number of consecutive reconnect attempts. Initially 0, and increments for each reconnect.
+	 * The number of consecutive rejoin attempts. Initially 0, and increments for each rejoin.
 	 * When a connection is successfully established, it resets to 0.
 	 */
-	public reconnectAttempts: number;
+	public rejoinAttempts: number;
 
 	/**
 	 * The state of the voice connection
@@ -204,7 +204,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 		super();
 
 		this.debug = debug ? (message: string) => this.emit('debug', message) : null;
-		this.reconnectAttempts = 0;
+		this.rejoinAttempts = 0;
 
 		this.onNetworkingClose = this.onNetworkingClose.bind(this);
 		this.onNetworkingStateChange = this.onNetworkingStateChange.bind(this);
@@ -255,7 +255,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 		}
 
 		if (newState.status === VoiceConnectionStatus.Ready) {
-			this.reconnectAttempts = 0;
+			this.rejoinAttempts = 0;
 		}
 
 		// If destroyed, the adapter can also be destroyed so it can be cleaned up by the user
@@ -379,7 +379,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 				...this.state,
 				status: VoiceConnectionStatus.Signalling,
 			};
-			this.reconnectAttempts++;
+			this.rejoinAttempts++;
 			if (!this.state.adapter.sendPayload(createJoinVoiceChannelPayload(this.joinConfig))) {
 				this.state = {
 					...this.state,
@@ -517,7 +517,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 	 * Attempts to rejoin (better explanation soon:tm:)
 	 *
 	 * @remarks
-	 * Calling this method successfully will automatically increment the `reconnectAttempts` counter,
+	 * Calling this method successfully will automatically increment the `rejoinAttempts` counter,
 	 * which you can use to inform whether or not you'd like to keep attempting to reconnect your
 	 * voice connection.
 	 *
@@ -528,7 +528,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 			return false;
 		}
 
-		this.reconnectAttempts++;
+		this.rejoinAttempts++;
 		Object.assign(this.joinConfig, joinConfig);
 		if (!this.state.adapter.sendPayload(createJoinVoiceChannelPayload(this.joinConfig))) {
 			this.state = {

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -3,6 +3,7 @@ import {
 	createVoiceConnection,
 	VoiceConnection,
 	VoiceConnectionConnectingState,
+	VoiceConnectionDisconnectReason,
 	VoiceConnectionSignallingState,
 	VoiceConnectionStatus,
 } from '../VoiceConnection';
@@ -441,7 +442,7 @@ describe('VoiceConnection#reconnect', () => {
 	test('Does nothing in a non-disconnected state', () => {
 		const { voiceConnection, adapter } = createFakeVoiceConnection();
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Signalling);
-		expect(voiceConnection.reconnect()).toBe(false);
+		expect(voiceConnection.rejoin()).toBe(false);
 		expect(voiceConnection.reconnectAttempts).toBe(0);
 		expect(adapter.sendPayload).not.toHaveBeenCalled();
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Signalling);
@@ -455,9 +456,10 @@ describe('VoiceConnection#reconnect', () => {
 		voiceConnection.state = {
 			...(voiceConnection.state as VoiceConnectionSignallingState),
 			status: VoiceConnectionStatus.Disconnected,
+			reason: VoiceConnectionDisconnectReason.WebSocketClose,
 			closeCode: 1000,
 		};
-		expect(voiceConnection.reconnect()).toBe(true);
+		expect(voiceConnection.rejoin()).toBe(true);
 		expect(voiceConnection.reconnectAttempts).toBe(1);
 		expect(adapter.sendPayload).toHaveBeenCalledWith(dummy);
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Signalling);
@@ -471,10 +473,11 @@ describe('VoiceConnection#reconnect', () => {
 		voiceConnection.state = {
 			...(voiceConnection.state as VoiceConnectionSignallingState),
 			status: VoiceConnectionStatus.Disconnected,
+			reason: VoiceConnectionDisconnectReason.WebSocketClose,
 			closeCode: 1000,
 		};
 		adapter.sendPayload.mockReturnValue(false);
-		expect(voiceConnection.reconnect()).toBe(false);
+		expect(voiceConnection.rejoin()).toBe(false);
 		expect(voiceConnection.reconnectAttempts).toBe(1);
 		expect(adapter.sendPayload).toHaveBeenCalledWith(dummy);
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Disconnected);

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -318,7 +318,7 @@ describe('VoiceConnection#onNetworkingClose', () => {
 		expect(adapter.sendPayload).not.toHaveBeenCalled();
 	});
 
-	test('Attempts reconnect for codes != 4014', () => {
+	test('Attempts rejoin for codes != 4014', () => {
 		const dummyPayload = Symbol('dummy') as any;
 		const { voiceConnection, adapter, joinConfig } = createFakeVoiceConnection();
 		DataStore.createJoinVoiceChannelPayload.mockImplementation((config) =>
@@ -327,10 +327,10 @@ describe('VoiceConnection#onNetworkingClose', () => {
 		voiceConnection['onNetworkingClose'](1234);
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Signalling);
 		expect(adapter.sendPayload).toHaveBeenCalledWith(dummyPayload);
-		expect(voiceConnection.reconnectAttempts).toBe(1);
+		expect(voiceConnection.rejoinAttempts).toBe(1);
 	});
 
-	test('Attempts reconnect for codes != 4014 (with adapter failure)', () => {
+	test('Attempts rejoin for codes != 4014 (with adapter failure)', () => {
 		const dummyPayload = Symbol('dummy') as any;
 		const { voiceConnection, adapter, joinConfig } = createFakeVoiceConnection();
 		DataStore.createJoinVoiceChannelPayload.mockImplementation((config) =>
@@ -340,7 +340,7 @@ describe('VoiceConnection#onNetworkingClose', () => {
 		voiceConnection['onNetworkingClose'](1234);
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Disconnected);
 		expect(adapter.sendPayload).toHaveBeenCalledWith(dummyPayload);
-		expect(voiceConnection.reconnectAttempts).toBe(1);
+		expect(voiceConnection.rejoinAttempts).toBe(1);
 	});
 });
 
@@ -438,17 +438,8 @@ describe('VoiceConnection#destroy', () => {
 	});
 });
 
-describe('VoiceConnection#reconnect', () => {
-	test('Does nothing in a non-disconnected state', () => {
-		const { voiceConnection, adapter } = createFakeVoiceConnection();
-		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Signalling);
-		expect(voiceConnection.rejoin()).toBe(false);
-		expect(voiceConnection.reconnectAttempts).toBe(0);
-		expect(adapter.sendPayload).not.toHaveBeenCalled();
-		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Signalling);
-	});
-
-	test('Reconnects in a disconnected state', () => {
+describe('VoiceConnection#rejoin', () => {
+	test('Rejoins in a disconnected state', () => {
 		const dummy = Symbol('dummy') as any;
 		DataStore.createJoinVoiceChannelPayload.mockImplementation(() => dummy);
 
@@ -460,7 +451,7 @@ describe('VoiceConnection#reconnect', () => {
 			closeCode: 1000,
 		};
 		expect(voiceConnection.rejoin()).toBe(true);
-		expect(voiceConnection.reconnectAttempts).toBe(1);
+		expect(voiceConnection.rejoinAttempts).toBe(1);
 		expect(adapter.sendPayload).toHaveBeenCalledWith(dummy);
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Signalling);
 	});
@@ -478,7 +469,7 @@ describe('VoiceConnection#reconnect', () => {
 		};
 		adapter.sendPayload.mockReturnValue(false);
 		expect(voiceConnection.rejoin()).toBe(false);
-		expect(voiceConnection.reconnectAttempts).toBe(1);
+		expect(voiceConnection.rejoinAttempts).toBe(1);
 		expect(adapter.sendPayload).toHaveBeenCalledWith(dummy);
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Disconnected);
 	});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Adds `VoiceConnection#disconnect` if you want to keep the VoiceConnection instance while still disconnecting from voice.
- Rename `VoiceConnection#reconnect` to `VoiceConnection#rejoin` for accuracy (it actually attempts to rejoin the voice channel, not just the voice server)
- Rename `VoiceConnection#reconnectAttempts` to `VoiceConnection#rejoinAttempts`
- Allow `VoiceConnection#rejoin` to take a partial JoinConfig. For example, `vc.rejoin({ channelId: 'newid' })`

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)