### PR TITLE
feat(Secretbox): throw fallback error when no encryption package installed

### DIFF
--- a/src/util/Secretbox.ts
+++ b/src/util/Secretbox.ts
@@ -20,7 +20,19 @@ const libs = {
 	}),
 };
 
-const methods: Record<any, any> = {};
+const fallbackError = () => {
+	throw new Error(
+		`Cannot play audio as no valid encryption package is installed.
+- Install sodium, libsodium-wrappers, or tweetnacl.
+- Use the generateDependencyReport() function for more information.\n`,
+	);
+};
+
+const methods: Record<any, any> = {
+	open: fallbackError,
+	close: fallbackError,
+	random: fallbackError,
+};
 
 void (async () => {
 	for (const libName of Object.keys(libs)) {

--- a/src/util/__tests__/Secretbox.test.ts
+++ b/src/util/__tests__/Secretbox.test.ts
@@ -1,7 +1,15 @@
 import { methods } from '../Secretbox';
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-jest.mock('tweetnacl', () => {}, { virtual: true });
+jest.mock(
+	'tweetnacl',
+	() => ({
+		secretbox: {
+			// eslint-disable-next-line @typescript-eslint/no-empty-function
+			open() {},
+		},
+	}),
+	{ virtual: true },
+);
 
 test('Does not throw error with a package installed', () => {
-	expect(() => methods.open).not.toThrowError();
+	expect(() => methods.open()).not.toThrowError();
 });

--- a/src/util/__tests__/Secretbox.test.ts
+++ b/src/util/__tests__/Secretbox.test.ts
@@ -1,0 +1,7 @@
+import { methods } from '../Secretbox';
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+jest.mock('tweetnacl', () => {}, { virtual: true });
+
+test('Does not throw error with a package installed', () => {
+	expect(() => methods.open).not.toThrowError();
+});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #128.

If no valid encryption package is installed, the following error is now thrown (rather than the obscure error shown in #128):

```
    throw new Error(`Cannot play audio as no valid encryption package is installed.
    ^

Error: Cannot play audio as no valid encryption package is installed.
- Install sodium, libsodium-wrappers, or tweetnacl.
- Use the generateDependencyReport() function for more information.
```


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes