### PR TITLE
refactor(Secretbox): type `methods` object

### DIFF
--- a/src/util/Secretbox.ts
+++ b/src/util/Secretbox.ts
@@ -1,5 +1,11 @@
+interface Methods {
+	open(buffer: Buffer, nonce: Buffer, secretKey: Uint8Array): Buffer | null;
+	close(opusPacket: Buffer, nonce: Buffer, secretKey: Uint8Array): Buffer;
+	random(bytes: number, nonce: Buffer): Buffer;
+}
+
 const libs = {
-	sodium: (sodium: any) => ({
+	sodium: (sodium: any): Methods => ({
 		open: sodium.api.crypto_secretbox_open_easy,
 		close: sodium.api.crypto_secretbox_easy,
 		random: (n: any, buffer?: Buffer) => {
@@ -8,17 +14,17 @@ const libs = {
 			return buffer;
 		},
 	}),
-	'libsodium-wrappers': (sodium: any) => ({
+	'libsodium-wrappers': (sodium: any): Methods => ({
 		open: sodium.crypto_secretbox_open_easy,
 		close: sodium.crypto_secretbox_easy,
 		random: (n: any) => sodium.randombytes_buf(n),
 	}),
-	tweetnacl: (tweetnacl: any) => ({
+	tweetnacl: (tweetnacl: any): Methods => ({
 		open: tweetnacl.secretbox.open,
 		close: tweetnacl.secretbox,
 		random: (n: any) => tweetnacl.randomBytes(n),
 	}),
-};
+} as const;
 
 const fallbackError = () => {
 	throw new Error(
@@ -28,19 +34,19 @@ const fallbackError = () => {
 	);
 };
 
-const methods: Record<any, any> = {
+const methods: Methods = {
 	open: fallbackError,
 	close: fallbackError,
 	random: fallbackError,
 };
 
 void (async () => {
-	for (const libName of Object.keys(libs)) {
+	for (const libName of Object.keys(libs) as (keyof typeof libs)[]) {
 		try {
 			// eslint-disable-next-line
 			const lib = require(libName);
 			if (libName === 'libsodium-wrappers' && lib.ready) await lib.ready; // eslint-disable-line no-await-in-loop
-			Object.assign(methods, (libs as any)[libName](lib));
+			Object.assign(methods, libs[libName](lib));
 			break;
 		} catch {} // eslint-disable-line no-empty
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR types the `methods` object from Secretbox and removes an `any` cast,
with the objective of improving the overall type safety in the library's
internals.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
