### PR TITLE
fix(Events): strengthen new state type for status events

### DIFF
--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -274,7 +274,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 
 		this.emit('stateChange', oldState, newState);
 		if (oldState.status !== newState.status) {
-			this.emit(newState.status, oldState, newState);
+			this.emit(newState.status, oldState, newState as any);
 		}
 	}
 

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -156,7 +156,10 @@ export type VoiceConnectionEvents = {
 	debug: (message: string) => Awaited<void>;
 	stateChange: (oldState: VoiceConnectionState, newState: VoiceConnectionState) => Awaited<void>;
 } & {
-	[status in VoiceConnectionStatus]: (oldState: VoiceConnectionState, newState: VoiceConnectionState & { status: status }) => Awaited<void>;
+	[status in VoiceConnectionStatus]: (
+		oldState: VoiceConnectionState,
+		newState: VoiceConnectionState & { status: status },
+	) => Awaited<void>;
 };
 
 /**

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -156,7 +156,7 @@ export type VoiceConnectionEvents = {
 	debug: (message: string) => Awaited<void>;
 	stateChange: (oldState: VoiceConnectionState, newState: VoiceConnectionState) => Awaited<void>;
 } & {
-	[status in VoiceConnectionStatus]: (oldState: VoiceConnectionState, newState: VoiceConnectionState) => Awaited<void>;
+	[status in VoiceConnectionStatus]: (oldState: VoiceConnectionState, newState: VoiceConnectionState & { status: status }) => Awaited<void>;
 };
 
 /**

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -304,7 +304,7 @@ export class AudioPlayer extends TypedEmitter<AudioPlayerEvents> {
 
 		this.emit('stateChange', oldState, this._state);
 		if (oldState.status !== newState.status || didChangeResources) {
-			this.emit(newState.status, oldState, this._state);
+			this.emit(newState.status, oldState, this._state as any);
 		}
 		this.debug?.(`state change:\nfrom ${stringifyState(oldState)}\nto ${stringifyState(newState)}`);
 	}

--- a/src/audio/AudioPlayer.ts
+++ b/src/audio/AudioPlayer.ts
@@ -145,7 +145,10 @@ export type AudioPlayerEvents = {
 	subscribe: (subscription: PlayerSubscription) => Awaited<void>;
 	unsubscribe: (subscription: PlayerSubscription) => Awaited<void>;
 } & {
-	[status in AudioPlayerStatus]: (oldState: AudioPlayerState, newState: AudioPlayerState) => Awaited<void>;
+	[status in AudioPlayerStatus]: (
+		oldState: AudioPlayerState,
+		newState: AudioPlayerState & { status: status },
+	) => Awaited<void>;
 };
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- This makes `VoiceConnection` emits status events with the their new state type
- Code with new typings
```ts
<VoiceConnection>.on(VoiceConnectionStatus.Ready, (_, newState: VoiceConnectionReadyState) => {
	// code
})
```
in favor of
```ts
<VoiceConnection>.on(VoiceConnectionStatus.Ready, (_, newState: VoiceConnectionState) => {
	if (newState.status === VoiceConnectionStatus.Ready) {
		// code
	}
	// or
	const readyState = newState as VoiceConnectionReadyState;
	// code
})
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)