### PR TITLE
fix(VoiceConnection): stuck on signalling state when rejoining the same channel on ready state

### DIFF
--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -531,13 +531,19 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 			return false;
 		}
 
-		this.rejoinAttempts++;
+		let notConnected = true;
+		if (this.state.status === VoiceConnectionStatus.Ready && joinConfig?.channelId === this.joinConfig.channelId) {
+			notConnected = false;
+		}
+		if (notConnected) this.rejoinAttempts++;
 		Object.assign(this.joinConfig, joinConfig);
 		if (this.state.adapter.sendPayload(createJoinVoiceChannelPayload(this.joinConfig))) {
-			this.state = {
-				...this.state,
-				status: VoiceConnectionStatus.Signalling,
-			};
+			if (notConnected) {
+				this.state = {
+					...this.state,
+					status: VoiceConnectionStatus.Signalling,
+				};
+			}
 			return true;
 		}
 

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -531,17 +531,12 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 			return false;
 		}
 
-		let notConnected = true;
-		if (
-			this.state.status === VoiceConnectionStatus.Ready &&
-			(!joinConfig || joinConfig.channelId === this.joinConfig.channelId)
-		) {
-			notConnected = false;
-		}
-		if (notConnected) this.rejoinAttempts++;
+		const notReady = this.state.status !== VoiceConnectionStatus.Ready;
+
+		if (notReady) this.rejoinAttempts++;
 		Object.assign(this.joinConfig, joinConfig);
 		if (this.state.adapter.sendPayload(createJoinVoiceChannelPayload(this.joinConfig))) {
-			if (notConnected) {
+			if (notReady) {
 				this.state = {
 					...this.state,
 					status: VoiceConnectionStatus.Signalling,

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -532,7 +532,10 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 		}
 
 		let notConnected = true;
-		if (this.state.status === VoiceConnectionStatus.Ready && joinConfig?.channelId === this.joinConfig.channelId) {
+		if (
+			this.state.status === VoiceConnectionStatus.Ready &&
+			(!joinConfig || joinConfig.channelId === this.joinConfig.channelId)
+		) {
 			notConnected = false;
 		}
 		if (notConnected) this.rejoinAttempts++;

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -4,6 +4,7 @@ import {
 	VoiceConnection,
 	VoiceConnectionConnectingState,
 	VoiceConnectionDisconnectReason,
+	VoiceConnectionReadyState,
 	VoiceConnectionSignallingState,
 	VoiceConnectionStatus,
 } from '../VoiceConnection';
@@ -534,6 +535,21 @@ describe('VoiceConnection#rejoin', () => {
 		expect(voiceConnection.rejoinAttempts).toBe(1);
 		expect(adapter.sendPayload).toHaveBeenCalledWith(dummy);
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Signalling);
+	});
+
+	test('Rejoins in a ready state', () => {
+		const dummy = Symbol('dummy') as any;
+		DataStore.createJoinVoiceChannelPayload.mockImplementation(() => dummy);
+
+		const { voiceConnection, adapter } = createFakeVoiceConnection();
+		voiceConnection.state = {
+			...(voiceConnection.state as VoiceConnectionReadyState),
+			status: VoiceConnectionStatus.Ready,
+		};
+		expect(voiceConnection.rejoin()).toBe(true);
+		expect(voiceConnection.rejoinAttempts).toBe(0);
+		expect(adapter.sendPayload).toHaveBeenCalledWith(dummy);
+		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Ready);
 	});
 
 	test('Stays in the disconnected state when the adapter fails', () => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When using `<VoiceConnection>.rejoin()` with the same channel on ready state, the networking state is not changed. This makes the connection state stuck on the signalling status.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
