### PR TITLE
fix(VoiceConnection): disconnect method now actually disconnects

### DIFF
--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -499,6 +499,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 		) {
 			return false;
 		}
+		Object.assign(this.joinConfig, { channelId: null });
 		if (!this.state.adapter.sendPayload(createJoinVoiceChannelPayload(this.joinConfig))) {
 			this.state = {
 				adapter: this.state.adapter,

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -499,7 +499,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 		) {
 			return false;
 		}
-		Object.assign(this.joinConfig, { channelId: null });
+		this.joinConfig.channelId = null;
 		if (!this.state.adapter.sendPayload(createJoinVoiceChannelPayload(this.joinConfig))) {
 			this.state = {
 				adapter: this.state.adapter,

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -496,7 +496,17 @@ describe('VoiceConnection#disconnect', () => {
 			adapter,
 			networking: new Networking.Networking({} as any, false),
 		};
+		const leavePayload = Symbol('dummy');
+		DataStore.createJoinVoiceChannelPayload.mockImplementation(() => leavePayload as any);
 		expect(voiceConnection.disconnect()).toBe(true);
+		expect(voiceConnection.joinConfig).toMatchObject({
+			channelId: null,
+			guildId: '2',
+			selfDeaf: true,
+			selfMute: false,
+		});
+		expect(DataStore.createJoinVoiceChannelPayload).toHaveBeenCalledWith(voiceConnection.joinConfig);
+		expect(adapter.sendPayload).toHaveBeenCalledWith(leavePayload);
 		expect(voiceConnection.state).toMatchObject({
 			status: VoiceConnectionStatus.Disconnected,
 			reason: VoiceConnectionDisconnectReason.Manual,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #138.

Calling `VoiceConnection#disconnect()` didn't actually send the correct voice state update packet to Discord. This has been fixed to null the channelId before sending the packet, and a test exposing this has been added.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes