### PR TITLE
feat: voice channel groups

### DIFF
--- a/examples/music-bot/package.json
+++ b/examples/music-bot/package.json
@@ -19,7 +19,7 @@
 		"discord.js": "^13.0.0-dev.02693bc02f45980d8165820a103220f0027b96b7",
 		"libsodium-wrappers": "^0.7.9",
 		"youtube-dl-exec": "^1.2.4",
-		"ytdl-core": "^4.8.2"
+		"ytdl-core": "^4.8.3"
 	},
 	"devDependencies": {
 		"tsconfig-paths": "^3.9.0",

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -49,7 +49,7 @@ export function getGroups() {
 	return groups;
 }
 
-export function getVoiceConnections(group: 'default'): Map<string, VoiceConnection>;
+export function getVoiceConnections(group?: 'default'): Map<string, VoiceConnection>;
 export function getVoiceConnections(group: string): Map<string, VoiceConnection> | undefined;
 /**
  * Retrieves all the voice connections under the given group name. Defaults to the 'default' group.

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -49,13 +49,15 @@ export function getGroups() {
 	return groups;
 }
 
+export function getVoiceConnections(group: 'default'): Map<string, VoiceConnection>;
+export function getVoiceConnections(group: string): Map<string, VoiceConnection> | undefined;
 /**
  * Retrieves all the voice connections under the given group name. Defaults to the 'default' group.
  * @param group - The group to look up
  * @returns The map of voice connections
  */
 export function getVoiceConnections(group = 'default') {
-	return groups.get(group) ?? new Map();
+	return groups.get(group);
 }
 
 /**
@@ -65,11 +67,11 @@ export function getVoiceConnections(group = 'default') {
  * @returns The voice connection, if it exists
  */
 export function getVoiceConnection(guildId: string, group = 'default') {
-	return getVoiceConnections(group).get(guildId);
+	return getVoiceConnections(group)?.get(guildId);
 }
 
 export function untrackVoiceConnection(voiceConnection: VoiceConnection) {
-	return getVoiceConnections(voiceConnection.joinConfig.group)!.delete(voiceConnection.joinConfig.guildId);
+	return getVoiceConnections(voiceConnection.joinConfig.group)?.delete(voiceConnection.joinConfig.guildId);
 }
 
 export function trackVoiceConnection(voiceConnection: VoiceConnection) {

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -35,6 +35,10 @@ function createKey({ guildId, group }: { guildId: string; group: string }) {
 	return guildId + group;
 }
 
+export function getVoiceConnections() {
+	return voiceConnections;
+}
+
 export function getVoiceConnection(guildId: string, group = 'default') {
 	return voiceConnections.get(createKey({ guildId, group }));
 }

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -29,8 +29,7 @@ export function createJoinVoiceChannelPayload(config: JoinConfig) {
 }
 
 // Voice Connections
-type VoiceConnectionMap = Map<string, VoiceConnection>;
-const groups: Map<string, VoiceConnectionMap> = new Map();
+const groups: Map<string, Map<string, VoiceConnection>> = new Map();
 groups.set('default', new Map());
 
 function getOrCreateGroup(group: string) {

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -7,6 +7,7 @@ export interface JoinConfig {
 	channelId: string | null;
 	selfDeaf: boolean;
 	selfMute: boolean;
+	group: string;
 }
 
 /**
@@ -30,16 +31,20 @@ export function createJoinVoiceChannelPayload(config: JoinConfig) {
 // Voice Connections
 const voiceConnections: Map<string, VoiceConnection> = new Map();
 
-export function getVoiceConnection(guildId: string) {
-	return voiceConnections.get(guildId);
+function createKey({ guildId, group }: { guildId: string; group: string }) {
+	return guildId + group;
 }
 
-export function untrackVoiceConnection(guildId: string) {
-	return voiceConnections.delete(guildId);
+export function getVoiceConnection(guildId: string, group = 'default') {
+	return voiceConnections.get(createKey({ guildId, group }));
 }
 
-export function trackVoiceConnection(guildId: string, voiceConnection: VoiceConnection) {
-	return voiceConnections.set(guildId, voiceConnection);
+export function untrackVoiceConnection(voiceConnection: VoiceConnection) {
+	return voiceConnections.delete(createKey(voiceConnection.joinConfig));
+}
+
+export function trackVoiceConnection(voiceConnection: VoiceConnection) {
+	return voiceConnections.set(createKey(voiceConnection.joinConfig), voiceConnection);
 }
 
 // Audio Players

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -29,26 +29,52 @@ export function createJoinVoiceChannelPayload(config: JoinConfig) {
 }
 
 // Voice Connections
-const voiceConnections: Map<string, VoiceConnection> = new Map();
+type VoiceConnectionMap = Map<string, VoiceConnection>;
+const groups: Map<string, VoiceConnectionMap> = new Map();
+groups.set('default', new Map());
 
-function createKey({ guildId, group }: { guildId: string; group: string }) {
-	return guildId + group;
+function getOrCreateGroup(group: string) {
+	const existing = groups.get(group);
+	if (existing) return existing;
+	const map = new Map();
+	groups.set(group, map);
+	return map;
 }
 
-export function getVoiceConnections() {
-	return voiceConnections;
+/**
+ * Retrieves the map of group names to maps of voice connections. By default, all voice connections
+ * are created under the 'default' group.
+ * @returns The group map
+ */
+export function getGroups() {
+	return groups;
 }
 
+/**
+ * Retrieves all the voice connections under the given group name. Defaults to the 'default' group.
+ * @param group - The group to look up
+ * @returns The map of voice connections
+ */
+export function getVoiceConnections(group = 'default') {
+	return groups.get(group) ?? new Map();
+}
+
+/**
+ * Finds a voice connection with the given guild ID and group. Defaults to the 'default' group.
+ * @param guildId - The guild ID of the voice connection
+ * @param group - the group that the voice connection was registered with
+ * @returns The voice connection, if it exists
+ */
 export function getVoiceConnection(guildId: string, group = 'default') {
-	return voiceConnections.get(createKey({ guildId, group }));
+	return getVoiceConnections(group).get(guildId);
 }
 
 export function untrackVoiceConnection(voiceConnection: VoiceConnection) {
-	return voiceConnections.delete(createKey(voiceConnection.joinConfig));
+	return getVoiceConnections(voiceConnection.joinConfig.group)!.delete(voiceConnection.joinConfig.guildId);
 }
 
 export function trackVoiceConnection(voiceConnection: VoiceConnection) {
-	return voiceConnections.set(createKey(voiceConnection.joinConfig), voiceConnection);
+	return getOrCreateGroup(voiceConnection.joinConfig.group).set(voiceConnection.joinConfig.guildId, voiceConnection);
 }
 
 // Audio Players

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -478,7 +478,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 			throw new Error('Cannot destroy VoiceConnection - it has already been destroyed');
 		}
 		if (getVoiceConnection(this.joinConfig.guildId) === this) {
-			untrackVoiceConnection(this.joinConfig.guildId);
+			untrackVoiceConnection(this);
 		}
 		if (adapterAvailable) {
 			this.state.adapter.sendPayload(createJoinVoiceChannelPayload({ ...this.joinConfig, channelId: null }));
@@ -527,7 +527,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 	 *
 	 * A state transition from Disconnected to Signalling will be observed when this is called.
 	 */
-	public rejoin(joinConfig?: Omit<JoinConfig, 'guildId'>) {
+	public rejoin(joinConfig?: Omit<JoinConfig, 'guildId' | 'group'>) {
 		if (this.state.status === VoiceConnectionStatus.Destroyed) {
 			return false;
 		}
@@ -652,7 +652,7 @@ export function createVoiceConnection(joinConfig: JoinConfig, options: CreateVoi
 	}
 
 	const voiceConnection = new VoiceConnection(joinConfig, options);
-	trackVoiceConnection(joinConfig.guildId, voiceConnection);
+	trackVoiceConnection(voiceConnection);
 	if (voiceConnection.state.status !== VoiceConnectionStatus.Destroyed) {
 		if (!voiceConnection.state.adapter.sendPayload(payload)) {
 			voiceConnection.state = {

--- a/src/__tests__/DataStore.test.ts
+++ b/src/__tests__/DataStore.test.ts
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/dot-notation */
+import * as DataStore from '../DataStore';
+import { VoiceConnection } from '../VoiceConnection';
+jest.mock('../VoiceConnection');
+
+function createVoiceConnection(joinConfig: Pick<DataStore.JoinConfig, 'group' | 'guildId'>): VoiceConnection {
+	return {
+		joinConfig: { channelId: '123', selfMute: false, selfDeaf: true, ...joinConfig },
+	} as any;
+}
+
+beforeEach(() => {
+	const groups = DataStore.getGroups();
+	for (const groupKey of groups.keys()) {
+		groups.delete(groupKey);
+	}
+	groups.set('default', new Map());
+});
+
+const voiceConnectionDefault = createVoiceConnection({ guildId: '123', group: 'default' });
+const voiceConnectionAbc = createVoiceConnection({ guildId: '123', group: 'abc' });
+
+describe('DataStore', () => {
+	test('VoiceConnection management respects group', () => {
+		DataStore.trackVoiceConnection(voiceConnectionDefault);
+		DataStore.trackVoiceConnection(voiceConnectionAbc);
+		expect(DataStore.getVoiceConnection('123')).toBe(voiceConnectionDefault);
+		expect(DataStore.getVoiceConnection('123', 'default')).toBe(voiceConnectionDefault);
+		expect(DataStore.getVoiceConnection('123', 'abc')).toBe(voiceConnectionAbc);
+
+		expect([...DataStore.getGroups().keys()]).toEqual(['default', 'abc']);
+
+		expect([...DataStore.getVoiceConnections().values()]).toEqual([voiceConnectionDefault]);
+		expect([...DataStore.getVoiceConnections('default').values()]).toEqual([voiceConnectionDefault]);
+		expect([...DataStore.getVoiceConnections('abc').values()]).toEqual([voiceConnectionAbc]);
+
+		DataStore.untrackVoiceConnection(voiceConnectionDefault);
+		expect(DataStore.getVoiceConnection('123')).toBeUndefined();
+		expect(DataStore.getVoiceConnection('123', 'abc')).toBe(voiceConnectionAbc);
+	});
+});

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -48,6 +48,7 @@ function createJoinConfig() {
 		guildId: '2',
 		selfDeaf: true,
 		selfMute: false,
+		group: 'default',
 	};
 }
 
@@ -80,7 +81,7 @@ describe('createVoiceConnection', () => {
 		});
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Signalling);
 		expect(DataStore.getVoiceConnection).toHaveBeenCalledTimes(1);
-		expect(DataStore.trackVoiceConnection).toHaveBeenCalledWith(joinConfig.guildId, voiceConnection);
+		expect(DataStore.trackVoiceConnection).toHaveBeenCalledWith(voiceConnection);
 		expect(DataStore.untrackVoiceConnection).not.toHaveBeenCalled();
 		expect(adapter.sendPayload).toHaveBeenCalledWith(mockPayload);
 	});
@@ -97,7 +98,7 @@ describe('createVoiceConnection', () => {
 		});
 		expect(voiceConnection.state.status).toBe(VoiceConnectionStatus.Disconnected);
 		expect(DataStore.getVoiceConnection).toHaveBeenCalledTimes(1);
-		expect(DataStore.trackVoiceConnection).toHaveBeenCalledWith(joinConfig.guildId, voiceConnection);
+		expect(DataStore.trackVoiceConnection).toHaveBeenCalledWith(voiceConnection);
 		expect(DataStore.untrackVoiceConnection).not.toHaveBeenCalled();
 		expect(adapter.sendPayload).toHaveBeenCalledWith(mockPayload);
 	});
@@ -160,7 +161,7 @@ describe('createVoiceConnection', () => {
 
 		const newAdapter = createFakeAdapter();
 		const newJoinConfig = createJoinConfig();
-		const { guildId, ...rejoinConfig } = newJoinConfig;
+		const { guildId, group, ...rejoinConfig } = newJoinConfig;
 		const newVoiceConnection = createVoiceConnection(newJoinConfig, {
 			debug: false,
 			adapterCreator: newAdapter.creator,
@@ -467,7 +468,7 @@ describe('VoiceConnection#destroy', () => {
 		DataStore.createJoinVoiceChannelPayload.mockImplementation(() => dummy as any);
 		voiceConnection.destroy();
 		expect(DataStore.getVoiceConnection).toHaveReturnedWith(voiceConnection);
-		expect(DataStore.untrackVoiceConnection).toHaveBeenCalledWith(joinConfig.guildId);
+		expect(DataStore.untrackVoiceConnection).toHaveBeenCalledWith(voiceConnection);
 		expect(DataStore.createJoinVoiceChannelPayload.mock.calls[0][0]).toMatchObject({
 			channelId: null,
 			guildId: joinConfig.guildId,

--- a/src/__tests__/joinVoiceChannel.test.ts
+++ b/src/__tests__/joinVoiceChannel.test.ts
@@ -1,0 +1,42 @@
+import { joinVoiceChannel } from '../joinVoiceChannel';
+import * as VoiceConnection from '../VoiceConnection';
+
+const adapterCreator = () => ({ destroy: jest.fn(), send: jest.fn() } as any);
+const createVoiceConnection = jest.spyOn(VoiceConnection, 'createVoiceConnection');
+
+beforeAll(() => {
+	createVoiceConnection.mockImplementation(() => null as any);
+});
+
+beforeEach(() => {
+	createVoiceConnection.mockClear();
+});
+
+describe('joinVoiceChannel', () => {
+	test('Uses default group', () => {
+		joinVoiceChannel({
+			channelId: '123',
+			guildId: '456',
+			adapterCreator,
+		});
+		expect(createVoiceConnection.mock.calls[0][0]).toMatchObject({
+			channelId: '123',
+			guildId: '456',
+			group: 'default',
+		});
+	});
+
+	test('Respects custom group', () => {
+		joinVoiceChannel({
+			channelId: '123',
+			guildId: '456',
+			group: 'abc',
+			adapterCreator,
+		});
+		expect(createVoiceConnection.mock.calls[0][0]).toMatchObject({
+			channelId: '123',
+			guildId: '456',
+			group: 'abc',
+		});
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,4 +19,4 @@ export {
 	VoiceConnectionEvents,
 } from './VoiceConnection';
 
-export { getVoiceConnection } from './DataStore';
+export { getVoiceConnection, getVoiceConnections, getGroups } from './DataStore';

--- a/src/joinVoiceChannel.ts
+++ b/src/joinVoiceChannel.ts
@@ -34,6 +34,10 @@ export interface JoinVoiceChannelOptions {
 	 * Whether to join the channel muted (defaults to true)
 	 */
 	selfMute?: boolean;
+	/**
+	 * An optional group identifier for the voice connection
+	 */
+	group?: string;
 }
 
 /**
@@ -46,6 +50,7 @@ export function joinVoiceChannel(options: JoinVoiceChannelOptions & CreateVoiceC
 	const joinConfig: JoinConfig = {
 		selfDeaf: true,
 		selfMute: false,
+		group: 'default',
 		...options,
 	};
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #144.

VoiceConnections are now stored in a 2D map (`{group_id -> {guild_id -> voice_connection}}`).

The default global group ID is `default` - this is so the update is backwards compatible. Users may optionally specify their own group ID, e.g. the client ID, when creating their voice connections if they wish to run more than one bot in the process.

Also exposes two new methods:

- `DataStore#getGroups()` - get the full 2D group map
- `DataStore#getVoiceConnections(group = 'default')` - gets the map of guild IDs to voice connections for the given group

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)