### PR TITLE
chore(Deps): update `discord-api-types` to `0.19.0`

### DIFF
--- a/examples/basic/adapter.ts
+++ b/examples/basic/adapter.ts
@@ -1,6 +1,6 @@
 import { DiscordGatewayAdapterCreator, DiscordGatewayAdapterLibraryMethods } from '../../';
 import { VoiceChannel, Snowflake, Client, Constants, WebSocketShard, Guild } from 'discord.js';
-import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v8';
+import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v9';
 
 const adapters = new Map<Snowflake, DiscordGatewayAdapterLibraryMethods>();
 const trackedClients = new Set<Client>();

--- a/examples/music-bot/package.json
+++ b/examples/music-bot/package.json
@@ -15,7 +15,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"@discordjs/opus": "^0.5.0",
-		"discord-api-types": "^0.18.1",
+		"discord-api-types": "^0.19.0",
 		"discord.js": "^13.0.0-dev.02693bc02f45980d8165820a103220f0027b96b7",
 		"libsodium-wrappers": "^0.7.9",
 		"youtube-dl-exec": "^1.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/ws": "^7.4.4",
-				"discord-api-types": "^0.18.1",
+				"discord-api-types": "^0.19.0",
 				"prism-media": "^1.3.1",
 				"tiny-typed-emitter": "^2.0.3",
 				"ws": "^7.4.4"
@@ -4009,9 +4009,9 @@
 			}
 		},
 		"node_modules/discord-api-types": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.18.1.tgz",
-			"integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg==",
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.19.0.tgz",
+			"integrity": "sha512-t2HKLd43Lbe+rf+ffYfKVv9Kk5f6p7sFqvO6CMV55ZB0PgZv8WigCkt9FoJciYo5S3Q6CGYK+WnE/ZG+6vkBDQ==",
 			"engines": {
 				"node": ">=12"
 			}
@@ -13869,9 +13869,9 @@
 			}
 		},
 		"discord-api-types": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.18.1.tgz",
-			"integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg=="
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.19.0.tgz",
+			"integrity": "sha512-t2HKLd43Lbe+rf+ffYfKVv9Kk5f6p7sFqvO6CMV55ZB0PgZv8WigCkt9FoJciYo5S3Q6CGYK+WnE/ZG+6vkBDQ=="
 		},
 		"doctrine": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	],
 	"dependencies": {
 		"@types/ws": "^7.4.4",
-		"discord-api-types": "^0.18.1",
+		"discord-api-types": "^0.19.0",
 		"prism-media": "^1.3.1",
 		"tiny-typed-emitter": "^2.0.3",
 		"ws": "^7.4.4"

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -1,4 +1,4 @@
-import { GatewayOPCodes } from 'discord-api-types/v8';
+import { GatewayOpcodes } from 'discord-api-types/v9';
 import { AudioPlayer } from './audio';
 import { VoiceConnection } from './VoiceConnection';
 
@@ -18,7 +18,7 @@ export interface JoinConfig {
  */
 export function createJoinVoiceChannelPayload(config: JoinConfig) {
 	return {
-		op: GatewayOPCodes.VoiceStateUpdate,
+		op: GatewayOpcodes.VoiceStateUpdate,
 		d: {
 			guild_id: config.guildId,
 			channel_id: config.channelId,

--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -1,4 +1,4 @@
-import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v8';
+import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v9';
 import { CreateVoiceConnectionOptions } from '.';
 import { AudioPlayer } from './audio/AudioPlayer';
 import { PlayerSubscription } from './audio/PlayerSubscription';

--- a/src/networking/Networking.ts
+++ b/src/networking/Networking.ts
@@ -1,4 +1,4 @@
-import { VoiceOPCodes } from 'discord-api-types/voice/v4';
+import { VoiceOpcodes } from 'discord-api-types/voice/v4';
 import { VoiceUDPSocket } from './VoiceUDPSocket';
 import { VoiceWebSocket } from './VoiceWebSocket';
 import * as secretbox from '../util/Secretbox';
@@ -282,7 +282,7 @@ export class Networking extends TypedEmitter<NetworkingEvents> {
 	private onWsOpen() {
 		if (this.state.code === NetworkingStatusCode.OpeningWs) {
 			const packet = {
-				op: VoiceOPCodes.Identify,
+				op: VoiceOpcodes.Identify,
 				d: {
 					server_id: this.state.connectionOptions.serverID,
 					user_id: this.state.connectionOptions.userID,
@@ -297,7 +297,7 @@ export class Networking extends TypedEmitter<NetworkingEvents> {
 			};
 		} else if (this.state.code === NetworkingStatusCode.Resuming) {
 			const packet = {
-				op: VoiceOPCodes.Resume,
+				op: VoiceOpcodes.Resume,
 				d: {
 					server_id: this.state.connectionOptions.serverID,
 					session_id: this.state.connectionOptions.sessionID,
@@ -347,9 +347,9 @@ export class Networking extends TypedEmitter<NetworkingEvents> {
 	 * @param packet - The received packet
 	 */
 	private onWsPacket(packet: any) {
-		if (packet.op === VoiceOPCodes.Hello && this.state.code !== NetworkingStatusCode.Closed) {
+		if (packet.op === VoiceOpcodes.Hello && this.state.code !== NetworkingStatusCode.Closed) {
 			this.state.ws.setHeartbeatInterval(packet.d.heartbeat_interval);
-		} else if (packet.op === VoiceOPCodes.Ready && this.state.code === NetworkingStatusCode.Identifying) {
+		} else if (packet.op === VoiceOpcodes.Ready && this.state.code === NetworkingStatusCode.Identifying) {
 			const { ip, port, ssrc, modes } = packet.d;
 
 			const udp = new VoiceUDPSocket({ ip, port });
@@ -361,7 +361,7 @@ export class Networking extends TypedEmitter<NetworkingEvents> {
 				.then((localConfig) => {
 					if (this.state.code !== NetworkingStatusCode.UdpHandshaking) return;
 					this.state.ws.sendPacket({
-						op: VoiceOPCodes.SelectProtocol,
+						op: VoiceOpcodes.SelectProtocol,
 						d: {
 							protocol: 'udp',
 							data: {
@@ -387,7 +387,7 @@ export class Networking extends TypedEmitter<NetworkingEvents> {
 				},
 			};
 		} else if (
-			packet.op === VoiceOPCodes.SessionDescription &&
+			packet.op === VoiceOpcodes.SessionDescription &&
 			this.state.code === NetworkingStatusCode.SelectingProtocol
 		) {
 			const { mode: encryptionMode, secret_key: secretKey } = packet.d;
@@ -406,7 +406,7 @@ export class Networking extends TypedEmitter<NetworkingEvents> {
 					packetsPlayed: 0,
 				},
 			};
-		} else if (packet.op === VoiceOPCodes.Resumed && this.state.code === NetworkingStatusCode.Resuming) {
+		} else if (packet.op === VoiceOpcodes.Resumed && this.state.code === NetworkingStatusCode.Resuming) {
 			this.state = {
 				...this.state,
 				code: NetworkingStatusCode.Ready,
@@ -497,7 +497,7 @@ export class Networking extends TypedEmitter<NetworkingEvents> {
 		if (state.connectionData.speaking === speaking) return;
 		state.connectionData.speaking = speaking;
 		state.ws.sendPacket({
-			op: VoiceOPCodes.Speaking,
+			op: VoiceOpcodes.Speaking,
 			d: {
 				speaking: speaking ? 1 : 0,
 				delay: 0,

--- a/src/networking/VoiceWebSocket.ts
+++ b/src/networking/VoiceWebSocket.ts
@@ -1,4 +1,4 @@
-import { VoiceOPCodes } from 'discord-api-types/voice/v4';
+import { VoiceOpcodes } from 'discord-api-types/voice/v4';
 import WebSocket, { MessageEvent } from 'ws';
 import { TypedEmitter } from 'tiny-typed-emitter';
 import { Awaited } from '../util/util';
@@ -111,7 +111,7 @@ export class VoiceWebSocket extends TypedEmitter<VoiceWebSocketEvents> {
 			return;
 		}
 
-		if (packet.op === VoiceOPCodes.HeartbeatAck) {
+		if (packet.op === VoiceOpcodes.HeartbeatAck) {
 			this.lastHeartbeatAck = Date.now();
 			this.missedHeartbeats = 0;
 			this.ping = this.lastHeartbeatAck - this.lastHeatbeatSend;
@@ -149,7 +149,7 @@ export class VoiceWebSocket extends TypedEmitter<VoiceWebSocketEvents> {
 		this.missedHeartbeats++;
 		const nonce = this.lastHeatbeatSend;
 		return this.sendPacket({
-			op: VoiceOPCodes.Heartbeat,
+			op: VoiceOpcodes.Heartbeat,
 			d: nonce,
 		});
 	}

--- a/src/networking/__tests__/VoiceWebSocket.test.ts
+++ b/src/networking/__tests__/VoiceWebSocket.test.ts
@@ -1,4 +1,4 @@
-import { VoiceOPCodes } from 'discord-api-types/voice/v4';
+import { VoiceOpcodes } from 'discord-api-types/voice/v4';
 import EventEmitter, { once } from 'events';
 import WS from 'jest-websocket-mock';
 import { VoiceWebSocket } from '../VoiceWebSocket';
@@ -93,10 +93,10 @@ describe('VoiceWebSocket: heartbeating', () => {
 		for (let i = 0; i < 10; i++) {
 			const packet: any = await server.nextMessage;
 			expect(packet).toMatchObject({
-				op: VoiceOPCodes.Heartbeat,
+				op: VoiceOpcodes.Heartbeat,
 			});
 			server.send({
-				op: VoiceOPCodes.HeartbeatAck,
+				op: VoiceOpcodes.HeartbeatAck,
 				d: packet.d,
 			});
 			expect(ws.ping).toBeGreaterThanOrEqual(0);

--- a/src/receive/VoiceReceiver.ts
+++ b/src/receive/VoiceReceiver.ts
@@ -1,4 +1,4 @@
-import { VoiceOPCodes } from 'discord-api-types/voice/v4';
+import { VoiceOpcodes } from 'discord-api-types/voice/v4';
 import { SILENCE_FRAME } from '../audio/AudioPlayer';
 import { ConnectionData, Networking, NetworkingState } from '../networking/Networking';
 import { VoiceUDPSocket } from '../networking/VoiceUDPSocket';
@@ -113,16 +113,16 @@ export class VoiceReceiver {
 	 * @param packet The received packet
 	 */
 	private onWsPacket(packet: any) {
-		if (packet.op === VoiceOPCodes.ClientDisconnect && typeof packet.d?.user_id === 'string') {
+		if (packet.op === VoiceOpcodes.ClientDisconnect && typeof packet.d?.user_id === 'string') {
 			this.ssrcMap.delete(packet.d.user_id);
 		} else if (
-			packet.op === VoiceOPCodes.Speaking &&
+			packet.op === VoiceOpcodes.Speaking &&
 			typeof packet.d?.user_id === 'string' &&
 			typeof packet.d?.ssrc === 'number'
 		) {
 			this.ssrcMap.update({ userId: packet.d.user_id, audioSSRC: packet.d.ssrc });
 		} else if (
-			packet.op === VoiceOPCodes.ClientConnect &&
+			packet.op === VoiceOpcodes.ClientConnect &&
 			typeof packet.d?.user_id === 'string' &&
 			typeof packet.d?.audio_ssrc === 'number'
 		) {

--- a/src/receive/__tests__/VoiceReceiver.test.ts
+++ b/src/receive/__tests__/VoiceReceiver.test.ts
@@ -4,7 +4,7 @@ import { VoiceConnection as _VoiceConnection, VoiceConnectionStatus } from '../.
 import { RTP_PACKET_DESKTOP, RTP_PACKET_CHROME, RTP_PACKET_ANDROID } from './fixtures/rtp';
 import EventEmitter, { once } from 'events';
 import { createVoiceReceiver } from '..';
-import { VoiceOPCodes } from 'discord-api-types/voice/v4';
+import { VoiceOpcodes } from 'discord-api-types/voice/v4';
 import * as fixtures from './fixtures/states';
 
 jest.mock('../../VoiceConnection');
@@ -95,7 +95,7 @@ describe('VoiceReceiver', () => {
 		test('CLIENT_DISCONNECT packet', () => {
 			const spy = jest.spyOn(receiver.ssrcMap, 'delete');
 			receiver['onWsPacket']({
-				op: VoiceOPCodes.ClientDisconnect,
+				op: VoiceOpcodes.ClientDisconnect,
 				d: {
 					user_id: '123abc',
 				},
@@ -106,7 +106,7 @@ describe('VoiceReceiver', () => {
 		test('SPEAKING packet', () => {
 			const spy = jest.spyOn(receiver.ssrcMap, 'update');
 			receiver['onWsPacket']({
-				op: VoiceOPCodes.Speaking,
+				op: VoiceOpcodes.Speaking,
 				d: {
 					ssrc: 123,
 					user_id: '123abc',
@@ -122,7 +122,7 @@ describe('VoiceReceiver', () => {
 		test('CLIENT_CONNECT packet', () => {
 			const spy = jest.spyOn(receiver.ssrcMap, 'update');
 			receiver['onWsPacket']({
-				op: VoiceOPCodes.ClientConnect,
+				op: VoiceOpcodes.ClientConnect,
 				d: {
 					audio_ssrc: 123,
 					video_ssrc: 43,
@@ -135,7 +135,7 @@ describe('VoiceReceiver', () => {
 				userId: '123abc',
 			});
 			receiver['onWsPacket']({
-				op: VoiceOPCodes.ClientConnect,
+				op: VoiceOpcodes.ClientConnect,
 				d: {
 					audio_ssrc: 123,
 					video_ssrc: 0,

--- a/src/util/adapter.ts
+++ b/src/util/adapter.ts
@@ -1,4 +1,4 @@
-import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v8';
+import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v9';
 
 /**
  * Methods that are provided by the @discordjs/voice library to implementations of


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Update `discord-api-types` and fix typing problem with `adapterCreator` option
`Type 'InternalDiscordGatewayAdapterCreator' is not assignable to type 'DiscordGatewayAdapterCreator'.`


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
