### PR TITLE
refactor(ConnectionOptions): change `xID` to `xId`

### DIFF
--- a/src/VoiceConnection.ts
+++ b/src/VoiceConnection.ts
@@ -334,10 +334,10 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 		const networking = new Networking(
 			{
 				endpoint: server.endpoint,
-				serverID: server.guild_id,
+				serverId: server.guild_id,
 				token: server.token,
-				sessionID: state.session_id,
-				userID: state.user_id,
+				sessionId: state.session_id,
+				userId: state.user_id,
 			},
 			Boolean(this.debug),
 		);

--- a/src/__tests__/VoiceConnection.test.ts
+++ b/src/__tests__/VoiceConnection.test.ts
@@ -320,10 +320,10 @@ describe('VoiceConnection#configureNetworking', () => {
 		expect(Networking.Networking).toHaveBeenCalledWith(
 			{
 				endpoint: server.endpoint,
-				serverID: server.guild_id,
+				serverId: server.guild_id,
 				token: server.token,
-				sessionID: state.session_id,
-				userID: state.user_id,
+				sessionId: state.session_id,
+				userId: state.user_id,
 			},
 			false,
 		);

--- a/src/networking/Networking.ts
+++ b/src/networking/Networking.ts
@@ -122,9 +122,9 @@ export type NetworkingState =
  * and VOICE_STATE_UPDATE packets.
  */
 interface ConnectionOptions {
-	serverID: string;
-	userID: string;
-	sessionID: string;
+	serverId: string;
+	userId: string;
+	sessionId: string;
 	token: string;
 	endpoint: string;
 }
@@ -284,9 +284,9 @@ export class Networking extends TypedEmitter<NetworkingEvents> {
 			const packet = {
 				op: VoiceOpcodes.Identify,
 				d: {
-					server_id: this.state.connectionOptions.serverID,
-					user_id: this.state.connectionOptions.userID,
-					session_id: this.state.connectionOptions.sessionID,
+					server_id: this.state.connectionOptions.serverId,
+					user_id: this.state.connectionOptions.userId,
+					session_id: this.state.connectionOptions.sessionId,
 					token: this.state.connectionOptions.token,
 				},
 			};
@@ -299,8 +299,8 @@ export class Networking extends TypedEmitter<NetworkingEvents> {
 			const packet = {
 				op: VoiceOpcodes.Resume,
 				d: {
-					server_id: this.state.connectionOptions.serverID,
-					session_id: this.state.connectionOptions.sessionID,
+					server_id: this.state.connectionOptions.serverId,
+					session_id: this.state.connectionOptions.sessionId,
 					token: this.state.connectionOptions.token,
 				},
 			};


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This changes all mentions of `xID` in ConnectionOptions to `xId` for consistency with everything else


**Status and versioning classification:**
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
