### PR TITLE
fix(Examples): destroy discord.js v12 adapter less readily

### DIFF
--- a/examples/basic/adapter.ts
+++ b/examples/basic/adapter.ts
@@ -27,7 +27,7 @@ function trackClient(client: Client) {
 				adapters.get(guildId)?.destroy();
 			}
 		}
-		trackedShards.set(shardID, new Set());
+		trackedShards.delete(shardID);
 	});
 }
 

--- a/examples/basic/adapter.ts
+++ b/examples/basic/adapter.ts
@@ -23,8 +23,8 @@ function trackClient(client: Client) {
 	client.on(Constants.Events.SHARD_DISCONNECT, (_, shardID) => {
 		const guilds = trackedShards.get(shardID);
 		if (guilds) {
-			for (const guildId of guilds.values()) {
-				adapters.get(guildId)?.destroy();
+			for (const guildID of guilds.values()) {
+				adapters.get(guildID)?.destroy();
 			}
 		}
 		trackedShards.delete(shardID);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adjusts the discord.js v12 adapter to match the same destroy conditions given by the adapter provided with discord.js v13.

Resolves #153 


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes