### PR TITLE
refactor(AudioPlayer): use this.once instead of events.once

### DIFF
--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -1,5 +1,5 @@
 import { Edge, findPipeline, StreamType, TransformerType } from './TransformerGraph';
-import { once, pipeline, Readable } from 'stream';
+import { pipeline, Readable } from 'stream';
 import { noop } from '../util/util';
 import { VolumeTransformer, opus } from 'prism-media';
 import { AudioPlayer, SILENCE_FRAME } from './AudioPlayer';
@@ -109,9 +109,7 @@ export class AudioResource<T = unknown> {
 			}
 		}
 
-		once(this.playStream, 'readable')
-			.then(() => (this.started = true))
-			.catch(noop);
+		this.playStream.once('readable', () => (this.started = true));
 	}
 
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This pr replaces the `once(this.playStream, 'readable')` listener inside audioResouce with a proper `this.playStream.once(...)` listener.
Personally i experienced alot of `audioPlayer failed to enter state playing in ????ms` errors prior to this fix.
The timeout duration had no effect on this.
I calculated that there was a 6 ms latency when using `once(...)` compared to `this.playStream.once(...)`. During this 6 ms the `audioPlayer.play()` function executed missing the if statement for `resouce.playing` and attaching the event listeners **after** `audioResouce readable` event emitted.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
- Code changes have been tested against the Discord API, or there are no code changes
