### PR TITLE
refactor(Examples): remove unused imported binding

### DIFF
--- a/examples/basic/adapter.ts
+++ b/examples/basic/adapter.ts
@@ -1,5 +1,5 @@
 import { DiscordGatewayAdapterCreator, DiscordGatewayAdapterLibraryMethods } from '../../';
-import { VoiceChannel, Snowflake, Client, Constants, WebSocketShard, Guild } from 'discord.js';
+import { VoiceChannel, Snowflake, Client, Constants, Guild } from 'discord.js';
 import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v9';
 
 const adapters = new Map<Snowflake, DiscordGatewayAdapterLibraryMethods>();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The imported binding `WebSocketShard` is actually never used throughout the code in the `examples/basic/adapter.ts` file, so there's no point in it being there.

**Status and versioning classification:**

- [x] Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
