### PR TITLE
refactor(Examples): use ytdl-core instead of youtube-dl-exec

### DIFF
--- a/examples/music-bot/package.json
+++ b/examples/music-bot/package.json
@@ -14,12 +14,10 @@
 	"author": "Amish Shah <contact@shah.gg>",
 	"license": "MIT",
 	"dependencies": {
-		"@discordjs/opus": "^0.5.0",
-		"discord-api-types": "^0.19.0",
-		"discord.js": "^13.0.0-dev.328501b.1626912223",
+		"@discordjs/opus": "^0.5.3",
+		"discord.js": "^13.0.1",
 		"libsodium-wrappers": "^0.7.9",
-		"youtube-dl-exec": "^1.2.4",
-		"ytdl-core": "^4.8.3"
+		"ytdl-core": "^4.9.1"
 	},
 	"devDependencies": {
 		"tsconfig-paths": "^3.9.0",

--- a/examples/music-bot/src/bot.ts
+++ b/examples/music-bot/src/bot.ts
@@ -72,7 +72,7 @@ client.on('interactionCreate', async (interaction: Interaction) => {
 	let subscription = subscriptions.get(interaction.guildId);
 
 	if (interaction.commandName === 'play') {
-		await interaction.defer();
+		await interaction.deferReply();
 		// Extract the video URL from the command
 		const url = interaction.options.get('song')!.value! as string;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

1. Do not dependent on youtube-dl-exec anymore. 
2. Update other dependencies.

This PR can make beginner easier to get started

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
