### PR TITLE
Fix music-bot example crashing when url is not a correct link

### DIFF
--- a/examples/music-bot/src/bot.ts
+++ b/examples/music-bot/src/bot.ts
@@ -127,7 +127,7 @@ client.on('interactionCreate', async (interaction: Interaction) => {
 			await interaction.followUp(`Enqueued **${track.title}**`);
 		} catch (error) {
 			console.warn(error);
-			await interaction.reply('Failed to play track, please try again later!');
+			await interaction.followUp('Failed to play track, please try again later!');
 		}
 	} else if (interaction.commandName === 'skip') {
 		if (subscription) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Since `play` is a deferred command, the example should use `followUp` instead of `reply` in the error response. Using `reply` causes the bot to crash when the error is reached. Here is the stacktrace:

```sh
Error: No video id found: boom ba yah
    at Object.exports.getVideoID (/Users/yaojie/Work/bubba/node_modules/ytdl-core/lib/url-utils.js:63:11)
    at exports.<computed> (/Users/yaojie/Work/bubba/node_modules/ytdl-core/lib/info.js:476:29)
    at Function.<anonymous> (/Users/yaojie/Work/bubba/src/music/track.ts:86:33)
    at step (/Users/yaojie/Work/bubba/src/music/track.ts:44:23)
    at Object.next (/Users/yaojie/Work/bubba/src/music/track.ts:25:53)
    at /Users/yaojie/Work/bubba/src/music/track.ts:19:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/yaojie/Work/bubba/src/music/track.ts:15:12)
    at Function.Track.from (/Users/yaojie/Work/bubba/src/music/track.ts:114:16)
    at /Users/yaojie/Work/bubba/index.ts:57:35
/Users/yaojie/Work/bubba/node_modules/discord.js/src/structures/interfaces/InteractionResponses.js:89
    if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
                                             ^
Error [INTERACTION_ALREADY_REPLIED]: The reply to this interaction has already been sent or deferred.
    at CommandInteraction.reply (/Users/yaojie/Work/bubba/node_modules/discord.js/src/structures/interfaces/InteractionResponses.js:89:46)
    at /Users/yaojie/Work/bubba/index.ts:74:27
    at step (/Users/yaojie/Work/bubba/index.ts:34:23)
    at Object.throw (/Users/yaojie/Work/bubba/index.ts:15:53)
    at rejected (/Users/yaojie/Work/bubba/index.ts:7:65)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  [Symbol(code)]: 'INTERACTION_ALREADY_REPLIED'
}
```

**Status and versioning classification:**

Not sure how to classify this as i'm only fixing the example, I guess it's

Code changes have been tested against the Discord API, or there are no code changes