### PR TITLE
feat: export some types so they render in docs

### DIFF
--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -49,7 +49,17 @@ export function getGroups() {
 	return groups;
 }
 
+/**
+ * Retrieves all the voice connections under the 'default' group.
+ * @param group - The group to look up
+ * @returns The map of voice connections
+ */
 export function getVoiceConnections(group?: 'default'): Map<string, VoiceConnection>;
+/**
+ * Retrieves all the voice connections under the given group name.
+ * @param group - The group to look up
+ * @returns The map of voice connections
+ */
 export function getVoiceConnections(group: string): Map<string, VoiceConnection> | undefined;
 /**
  * Retrieves all the voice connections under the given group name. Defaults to the 'default' group.

--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -9,7 +9,7 @@ import { AudioPlayer, SILENCE_FRAME } from './AudioPlayer';
  *
  * @template T - the type for the metadata (if any) of the audio resource.
  */
-interface CreateAudioResourceOptions<T> {
+export interface CreateAudioResourceOptions<T> {
 	/**
 	 * The type of the input stream. Defaults to `StreamType.Arbitrary`.
 	 */
@@ -189,6 +189,21 @@ export function inferStreamType(stream: Readable): {
 	return { streamType: StreamType.Arbitrary, hasVolume: false };
 }
 
+/**
+ * Creates an audio resource that can be played be audio players.
+ *
+ * @remarks
+ * If the input is given as a string, then the inputType option will be overridden and FFmpeg will be used.
+ *
+ * If the input is not in the correct format, then a pipeline of transcoders and transformers will be created
+ * to ensure that the resultant stream is in the correct format for playback. This could involve using FFmpeg,
+ * Opus transcoders, and Ogg/WebM demuxers.
+ *
+ * @param input - The resource to play.
+ * @param options - Configurable options for creating the resource.
+ *
+ * @template T - the type for the metadata (if any) of the audio resource.
+ */
 export function createAudioResource<T>(
 	input: string | Readable,
 	options: CreateAudioResourceOptions<T> &
@@ -198,6 +213,21 @@ export function createAudioResource<T>(
 		>,
 ): AudioResource<T extends null | undefined ? null : T>;
 
+/**
+ * Creates an audio resource that can be played be audio players.
+ *
+ * @remarks
+ * If the input is given as a string, then the inputType option will be overridden and FFmpeg will be used.
+ *
+ * If the input is not in the correct format, then a pipeline of transcoders and transformers will be created
+ * to ensure that the resultant stream is in the correct format for playback. This could involve using FFmpeg,
+ * Opus transcoders, and Ogg/WebM demuxers.
+ *
+ * @param input - The resource to play.
+ * @param options - Configurable options for creating the resource.
+ *
+ * @template T - the type for the metadata (if any) of the audio resource.
+ */
 export function createAudioResource<T extends null | undefined>(
 	input: string | Readable,
 	options?: Omit<CreateAudioResourceOptions<T>, 'metadata'>,

--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -14,7 +14,7 @@ export {
 
 export { AudioPlayerError } from './AudioPlayerError';
 
-export { AudioResource, createAudioResource } from './AudioResource';
+export { AudioResource, CreateAudioResourceOptions, createAudioResource } from './AudioResource';
 
 export { PlayerSubscription } from './PlayerSubscription';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,4 +19,4 @@ export {
 	VoiceConnectionEvents,
 } from './VoiceConnection';
 
-export { getVoiceConnection, getVoiceConnections, getGroups } from './DataStore';
+export { JoinConfig, getVoiceConnection, getVoiceConnections, getGroups } from './DataStore';

--- a/src/receive/index.ts
+++ b/src/receive/index.ts
@@ -1,3 +1,4 @@
 export * from './VoiceReceiver';
 export * from './SSRCMap';
 export * from './AudioReceiveStream';
+export * from './SpeakingMap';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR exports the following:
- `CreateAudioResourceOptions` (parameter type in `createAudioResource`)
- `JoinConfig` (parameter type in `createVoiceConnection` and `VoiceConnection#rejoin`)
- `SpeakingMap` (type of `VoiceReceiver#speaking`) and `SpeakingMapEvents`

This is mainly so that these types show in the documentation, but I think these should be exported regardless of the documentation anyway.
    
There are some more unexported types referenced in the docs that I haven't exported because they seem more internal:
- `Awaited`
- `Edge` (`AudioResource#edges`)
- `Networking` (`VoiceConnection(Connecting|Ready)State#networking`)
- `ConnectionData` (`VoiceReceiver#connectionData` which is `@internal`)

(if these should be exported as well I'll export them as well)
    
This PR also documents the overloads for [`createAudioResource`](https://discordjs.github.io/voice/modules.html#createaudioresource) and [`getVoiceConnections`](https://discordjs.github.io/voice/modules.html#getvoiceconnections). Currently, no documentation is rendered for these two functions as Typedoc only considers the documentation for each overload.

https://typedoc.org/guides/options/#excludeinternal

**Status and versioning classification:**

- This PR changes the library's interface (methods or parameters added)

I think this counts as changing the library's interface because it exports some more types.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
