### PR TITLE
refactor: remove esModuleInterop from tsconfig.json

### DIFF
--- a/src/networking/VoiceWebSocket.ts
+++ b/src/networking/VoiceWebSocket.ts
@@ -1,5 +1,6 @@
 import { VoiceOpcodes } from 'discord-api-types/voice/v4';
-import WebSocket, { MessageEvent } from 'ws';
+import * as WebSocket from 'ws';
+import { MessageEvent } from 'ws';
 import { TypedEmitter } from 'tiny-typed-emitter';
 import { Awaited } from '../util/util';
 

--- a/src/util/entersState.ts
+++ b/src/util/entersState.ts
@@ -1,7 +1,8 @@
 import { VoiceConnection, VoiceConnectionStatus } from '../VoiceConnection';
 import { AudioPlayer, AudioPlayerStatus } from '../audio/AudioPlayer';
 import { abortAfter } from './abortAfter';
-import EventEmitter, { once } from 'events';
+import * as EventEmitter from 'events';
+import { once } from 'events';
 
 /**
  * Allows a voice connection a specified amount of time to enter a given state, otherwise rejects with an error.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
 		"declarationMap": true,
 		"outDir": "dist",
 		"incremental": true,
-		"esModuleInterop": true,
 		"skipLibCheck": true
 	},
 	"include": ["src/**/*.ts"],


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

By default `esModuleInterop` is set to false in `tsconfig.json`.  [check here](https://www.typescriptlang.org/tsconfig#esModuleInterop)

hence error thrown when, not using `esModuleInterop` in project

![image](https://user-images.githubusercontent.com/43092101/138860177-6a807de2-dfde-4414-bb9b-f3c3543c3b50.png)

**Status and versioning classification:**

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
