### PR TITLE
docs: include StreamType enum description in new docs

### DIFF
--- a/src/audio/TransformerGraph.ts
+++ b/src/audio/TransformerGraph.ts
@@ -24,19 +24,31 @@ const FFMPEG_OPUS_ARGUMENTS = [
 
 /**
  * The different types of stream that can exist within the pipeline.
- *
- * @remarks
- * - `Arbitrary` - the type of the stream at this point is unknown.
- * - `Raw` - the stream at this point is s16le PCM.
- * - `OggOpus` - the stream at this point is Opus audio encoded in an Ogg wrapper.
- * - `WebmOpus` - the stream at this point is Opus audio encoded in a WebM wrapper.
- * - `Opus` - the stream at this point is Opus audio, and the stream is in object-mode. This is ready to play.
  */
 export enum StreamType {
+	/**
+	 * The type of the stream at this point is unknown.
+	 */
 	Arbitrary = 'arbitrary',
+	
+	/**
+	 * The stream at this point is s16le PCM.
+	 */
 	Raw = 'raw',
+	
+	/**
+	 * The stream at this point is Opus audio encoded in an Ogg wrapper.
+	 */
 	OggOpus = 'ogg/opus',
+	
+	/**
+	 * The stream at this point is Opus audio encoded in a WebM wrapper.
+	 */
 	WebmOpus = 'webm/opus',
+	
+	/**
+	 * The stream at this point is Opus audio, and the stream is in object-mode. This is ready to play.
+	 */
 	Opus = 'opus',
 }
 

--- a/src/audio/TransformerGraph.ts
+++ b/src/audio/TransformerGraph.ts
@@ -30,22 +30,18 @@ export enum StreamType {
 	 * The type of the stream at this point is unknown.
 	 */
 	Arbitrary = 'arbitrary',
-	
 	/**
 	 * The stream at this point is s16le PCM.
 	 */
 	Raw = 'raw',
-	
 	/**
 	 * The stream at this point is Opus audio encoded in an Ogg wrapper.
 	 */
 	OggOpus = 'ogg/opus',
-	
 	/**
 	 * The stream at this point is Opus audio encoded in a WebM wrapper.
 	 */
 	WebmOpus = 'webm/opus',
-	
 	/**
 	 * The stream at this point is Opus audio, and the stream is in object-mode. This is ready to play.
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

https://discord.js.org/#/docs/voice/stable/typedef/StreamType

The link above does not have a description for the StreamType enum. This pull request should _hopefully_ include them.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
- Code changes ~~have been tested against the Discord API~~, or there are no code changes
