### PR TITLE
fix(Interaction): update interaction methods

### DIFF
--- a/examples/music-bot/src/bot.ts
+++ b/examples/music-bot/src/bot.ts
@@ -1,4 +1,4 @@
-import Discord, { Interaction, GuildMember, Snowflake } from 'discord.js';
+import Discord, { Interaction, GuildMember, Snowflake, Message } from 'discord.js';
 import {
 	AudioPlayerStatus,
 	AudioResource,
@@ -17,7 +17,7 @@ const client = new Discord.Client({ intents: ['GUILD_VOICE_STATES', 'GUILD_MESSA
 client.on('ready', () => console.log('Ready!'));
 
 // This contains the setup code for creating slash commands in a guild. The owner of the bot can send "!deploy" to create them.
-client.on('messageCreate', async (message) => {
+client.on('messageCreate', async (message: Message) => {
 	if (!message.guild) return;
 	if (!client.application?.owner) await client.application?.fetch();
 
@@ -72,9 +72,9 @@ client.on('interactionCreate', async (interaction: Interaction) => {
 	let subscription = subscriptions.get(interaction.guildId);
 
 	if (interaction.commandName === 'play') {
-		await interaction.defer();
+		await interaction.deferReply();
 		// Extract the video URL from the command
-		const url = interaction.options.get('song')!.value! as string;
+		const url = interaction.options.getString('song') as string;
 
 		// If a connection to the guild doesn't already exist and the user is in a voice channel, join that channel
 		// and create a subscription.

--- a/examples/music-bot/src/music/track.ts
+++ b/examples/music-bot/src/music/track.ts
@@ -1,6 +1,7 @@
 import { getInfo } from 'ytdl-core';
 import { AudioResource, createAudioResource, demuxProbe } from '@discordjs/voice';
 import { raw as ytdl } from 'youtube-dl-exec';
+const ytdla = require('ytdl-core')
 
 /**
  * This is the data required to create a Track object.
@@ -46,14 +47,7 @@ export class Track implements TrackData {
 	public createAudioResource(): Promise<AudioResource<Track>> {
 		return new Promise((resolve, reject) => {
 			const process = ytdl(
-				this.url,
-				{
-					o: '-',
-					q: '',
-					f: 'bestaudio[ext=webm+acodec=opus+asr=48000]/bestaudio',
-					r: '100K',
-				},
-				{ stdio: ['ignore', 'pipe', 'ignore'] },
+				this.url
 			);
 			if (!process.stdout) {
 				reject(new Error('No stdout'));
@@ -68,7 +62,7 @@ export class Track implements TrackData {
 			process
 				.once('spawn', () => {
 					demuxProbe(stream)
-						.then((probe: { stream: any; type: any; }) => resolve(createAudioResource(probe.stream, { metadata: this, inputType: probe.type })))
+						.then(async (probe: { stream: any; type: any; }) => resolve(createAudioResource(await ytdla(this.url), { metadata: this, inputType: probe.type })))
 						.catch(onError);
 				})
 				.catch(onError);


### PR DESCRIPTION
Updating the Interaction methods to the latest discord.js version
- interaction.defer() -> interaction.deferReply()
- interaction.get() -> interaction.getString()

Fixing the audio resource. The track was not being played and the parameters passed to ytdl() method was throwing an error, these parameters have been removed. Also, use probe.stream as parameter to createAudioResource makes the track don't be played, I changed this parameter to a ytdl method, imported from ytdl-core: await ytdla(this.url). These two modifications makes the bot work normally... (Sorry if I speak something wrong. I don't speak english very well =D)